### PR TITLE
#75: Straight-forward implementation of GCP Secret Manager support

### DIFF
--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>quarkus-google-cloud-spanner</artifactId>
       <version>0.5.0-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>io.quarkiverse.googlecloudservices</groupId>
+      <artifactId>quarkus-google-cloud-secret-manager</artifactId>
+      <version>0.5.0-SNAPSHOT</version>
+    </dependency>
 
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/SecretManagerResource.java
+++ b/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/SecretManagerResource.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.googlecloudservices.it;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+
+@Path("/secretmanager")
+public class SecretManagerResource {
+    @ConfigProperty(name = "quarkus.google.cloud.project-id")
+    String projectId;
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String secretManager() throws IOException {
+        try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+            SecretVersionName secretVersionName = SecretVersionName.of(projectId, "integration-test", "latest");
+            AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+            return response.getPayload().getData().toStringUtf8();
+        }
+    }
+
+}

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/GoogleServicesResourcesTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/GoogleServicesResourcesTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.googlecloudservices.it;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -59,4 +60,12 @@ public class GoogleServicesResourcesTest {
                 .statusCode(200);
     }
 
+    @Test
+    public void testSecretManager() {
+        given()
+                .when().get("/secretmanager")
+                .then()
+                .statusCode(200)
+                .body(is("integration-test-secret"));
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <module>storage</module>
         <module>firestore</module>
         <module>bigtable</module>
+        <module>secret-manager</module>
     </modules>
 
     <dependencyManagement>

--- a/secret-manager/README.md
+++ b/secret-manager/README.md
@@ -32,7 +32,7 @@ This will add the following to your pom.xml:
 ```
 
 ## Some example
-This is an example fetching a single secret from GCP Secret Manager. The first example is in Java, while the second is the equivalent version in Kotlin.
+This is an example fetching a single secret from GCP Secret Manager.
 
 First, you'll have to create the secret in the GCP Secret Manager, as described in Google's documentation at https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets.
 
@@ -56,26 +56,6 @@ public class GCPSecretManager {
             AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
             return response.getPayload().getData().toStringUtf8();
         }
-    }
-}
-```
-
-```kotlin
-import com.google.cloud.secretmanager.v1.SecretManagerServiceClient
-import com.google.cloud.secretmanager.v1.SecretVersionName
-import org.eclipse.microprofile.config.inject.ConfigProperty
-import javax.enterprise.context.RequestScoped
-
-@RequestScoped
-class GCPSecretManager {
-
-    @ConfigProperty(name = "secretManagerProjectId", defaultValue = "")
-    lateinit var secretManagerProjectId: String
-    
-    fun getSecretFromSecretManager(secretName: String): String {
-        val secretVersionName = SecretVersionName.of(secretManagerProjectId, secretName, "latest")
-        val client = SecretManagerServiceClient.create()
-        return client.accessSecretVersion(secretVersionName).payload.data.toStringUtf8()
     }
 }
 ```

--- a/secret-manager/README.md
+++ b/secret-manager/README.md
@@ -1,0 +1,55 @@
+# Quarkiverse - Google Cloud Services - Secret Manager
+
+This extension allows to inject the Google Cloud Platform Secret Manager client library inside your Quarkus application.
+
+## Bootstrapping the project
+
+First, we need a new project. Create a new project with the following command (replace the version placeholders with the correct ones):
+
+```shell script
+mvn io.quarkus:quarkus-maven-plugin:${quarkusVersion}:create \
+    -DprojectGroupId=org.acme \
+    -DprojectArtifactId=secretmanager-quickstart \
+    -Dextensions="resteasy-jackson,io.quarkiverse.googlecloudservices:quarkus-google-cloud-secret-manager:${googleCloudServicesVersion}"
+cd secretmanager-quickstart
+```
+
+This command generates a Maven project, importing the Google Cloud Secret Manager extension.
+
+If you already have your Quarkus project configured, you can add the `quarkus-google-cloud-secret-manager` extension to your project by running the following command in your project base directory:
+```shell script
+./mvnw quarkus:add-extension -Dextensions="io.quarkiverse.googlecloudservices:quarkus-google-cloud-secret-manager:${googleCloudServicesVersion}"
+```
+
+This will add the following to your pom.xml:
+
+```xml
+<dependency>
+    <groupId>io.quarkiverse.googlecloudservices</groupId>
+    <artifactId>quarkus-google-cloud-secret-manager</artifactId>
+    <version>${googleCloudServicesVersion}</version>
+</dependency>
+```
+
+## Some example
+This is an example fetching a single secret from GCP Secret Manager. The example is in Kotlin, but the code can be transformed into Java as well.
+
+```kotlin
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient
+import com.google.cloud.secretmanager.v1.SecretVersionName
+import org.eclipse.microprofile.config.inject.ConfigProperty
+import javax.enterprise.context.RequestScoped
+
+@RequestScoped
+class GCPSecretManager {
+
+    @ConfigProperty(name = "secretManagerProjectId", defaultValue = "")
+    lateinit var secretManagerProjectId: String
+    
+    fun getSecretFromSecretManager(secretName: String): String {
+        val secretVersionName = SecretVersionName.of(secretManagerProjectId, secretName, "latest")
+        val client = SecretManagerServiceClient.create()
+        return client.accessSecretVersion(secretVersionName).payload.data.toStringUtf8()
+    }
+}
+```

--- a/secret-manager/README.md
+++ b/secret-manager/README.md
@@ -1,6 +1,6 @@
 # Quarkiverse - Google Cloud Services - Secret Manager
 
-This extension allows to inject the Google Cloud Platform Secret Manager client library inside your Quarkus application.
+This extension allows to use the Google Cloud Platform Secret Manager client library inside your Quarkus application. The current implementation is focused on _accessing_ the secrets, but extending the implementation into also allowing to create or edit a secret might be a natural next step.
 
 ## Bootstrapping the project
 
@@ -32,7 +32,33 @@ This will add the following to your pom.xml:
 ```
 
 ## Some example
-This is an example fetching a single secret from GCP Secret Manager. The example is in Kotlin, but the code can be transformed into Java as well.
+This is an example fetching a single secret from GCP Secret Manager. The first example is in Java, while the second is the equivalent version in Kotlin.
+
+First, you'll have to create the secret in the GCP Secret Manager, as described in Google's documentation at https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets.
+
+The _secretName_ parameter in the examples below refer to the name you give your secret, whereas the injected _secretManagerProjectId_ refers to the name of your project on GCP.
+
+```java
+import com.google.cloud.secretmanager.v1.AccessSecretVersionResponse;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretVersionName;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@RequestScoped
+public class GCPSecretManager {
+
+    @ConfigProperty(name = "secretManagerProjectId", defaultValue = "")
+    String secretManagerProjectId;
+
+    public String getSecretFromSecretManager(String secretName) throws IOException {
+        try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
+            SecretVersionName secretVersionName = SecretVersionName.of(secretManagerProjectId, secretName, "latest");
+            AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+            return response.getPayload().getData().toStringUtf8();
+        }
+    }
+}
+```
 
 ```kotlin
 import com.google.cloud.secretmanager.v1.SecretManagerServiceClient

--- a/secret-manager/deployment/pom.xml
+++ b/secret-manager/deployment/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkiverse.googlecloudservices</groupId>
+        <artifactId>quarkus-google-cloud-secret-manager-parent</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-google-cloud-secret-manager-deployment</artifactId>
+    <name>Quarkus - Google Cloud Services - Secret Manager - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-core-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common-deployment</artifactId>
+            <version>0.5.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-common-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-secret-manager</artifactId>
+            <version>0.5.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/secret-manager/deployment/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/deployment/SecretManagerBuildSteps.java
+++ b/secret-manager/deployment/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/deployment/SecretManagerBuildSteps.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.googlecloudservices.secretmanager.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+
+public class SecretManagerBuildSteps {
+    private static final String FEATURE = "google-cloud-secret-manager";
+
+    @BuildStep
+    public FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+}

--- a/secret-manager/pom.xml
+++ b/secret-manager/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-google-cloud-services-parent</artifactId>
+        <groupId>io.quarkiverse.googlecloudservices</groupId>
+        <version>0.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-google-cloud-secret-manager-parent</artifactId>
+    <name>Quarkus - Google Cloud Services - Secret Manager</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>runtime</module>
+        <module>deployment</module>
+    </modules>
+
+</project>

--- a/secret-manager/runtime/pom.xml
+++ b/secret-manager/runtime/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.quarkiverse.googlecloudservices</groupId>
+        <artifactId>quarkus-google-cloud-secret-manager-parent</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-google-cloud-secret-manager</artifactId>
+    <name>Quarkus - Google Cloud Services - Secret Manager - Runtime</name>
+    <description>Use Google Cloud Secret Manager service</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common</artifactId>
+            <version>0.5.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-common-grpc</artifactId>
+            <version>0.5.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-secretmanager</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.checkerframework</groupId>
+                    <artifactId>checker-qual</artifactId>
+                </exclusion>
+                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
+                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
+                <exclusion>
+                    <groupId>io.grpc</groupId>
+                    <artifactId>grpc-netty-shaded</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-grpc-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <phase>compile</phase>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
+                            </deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/secret-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/secret-manager/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,12 @@
+---
+name: "Google Cloud Secret Manager"
+metadata:
+  keywords:
+    - "secretmanager"
+    - "google cloud"
+    - "gcloud"
+    - "gcp"
+  categories:
+    - "cloud"
+    - "security"
+  status: "experimental"


### PR DESCRIPTION
For my project, I needed Secret Manager support for Quarkus native, so I decided to try to figure it out myself.

This is an implementation heavily inspired by the pubsub- and firestore-implementation. It's also an implementation that's very close to the original Google client library in user experience.

So I'm drafting this to hear your thoughts on it. Totally understand if it's too early.