### PR TITLE
Upgrade Testcontainers to 1.15.1

### DIFF
--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -76,7 +76,7 @@
       <dependency>
           <groupId>org.testcontainers</groupId>
           <artifactId>testcontainers</artifactId>
-          <version>1.14.2</version>
+          <version>1.15.1</version>
           <scope>test</scope>
       </dependency>
     <dependency>


### PR DESCRIPTION
Might fix the Ryuk image download failures

@loicmathieu if you could merge this one quickly, that might fix the Ecosystem CI failure we had last night.