### PR TITLE
Add Cloud Platform Auth Scope

### DIFF
--- a/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/SecretManagerResource.java
+++ b/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/SecretManagerResource.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.googlecloudservices.it;
 
-import java.io.IOException;
-
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -15,17 +14,19 @@ import com.google.cloud.secretmanager.v1.SecretVersionName;
 
 @Path("/secretmanager")
 public class SecretManagerResource {
+
     @ConfigProperty(name = "quarkus.google.cloud.project-id")
     String projectId;
 
+    @Inject
+    SecretManagerServiceClient client;
+
     @GET
     @Produces(MediaType.TEXT_PLAIN)
-    public String secretManager() throws IOException {
-        try (SecretManagerServiceClient client = SecretManagerServiceClient.create()) {
-            SecretVersionName secretVersionName = SecretVersionName.of(projectId, "integration-test", "latest");
-            AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
-            return response.getPayload().getData().toStringUtf8();
-        }
+    public String secretManager() {
+        SecretVersionName secretVersionName = SecretVersionName.of(projectId, "integration-test", "latest");
+        AccessSecretVersionResponse response = client.accessSecretVersion(secretVersionName);
+        return response.getPayload().getData().toStringUtf8();
     }
 
 }

--- a/secret-manager/deployment/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/deployment/SecretManagerBuildSteps.java
+++ b/secret-manager/deployment/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/deployment/SecretManagerBuildSteps.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.googlecloudservices.secretmanager.deployment;
 
+import io.quarkiverse.googlecloudservices.secretmanager.runtime.SecretManagerProducer;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 
@@ -9,5 +11,10 @@ public class SecretManagerBuildSteps {
     @BuildStep
     public FeatureBuildItem feature() {
         return new FeatureBuildItem(FEATURE);
+    }
+
+    @BuildStep
+    public AdditionalBeanBuildItem producer() {
+        return new AdditionalBeanBuildItem(SecretManagerProducer.class);
     }
 }

--- a/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/SecretManagerProducer.java
+++ b/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/SecretManagerProducer.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.googlecloudservices.secretmanager.runtime;
+
+import java.io.IOException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceClient;
+import com.google.cloud.secretmanager.v1.SecretManagerServiceSettings;
+
+import io.quarkiverse.googlecloudservices.common.GcpConfiguration;
+
+/**
+ * Producer for the Google Cloud Secret Manager service.
+ */
+@ApplicationScoped
+public class SecretManagerProducer {
+
+    @Inject
+    GoogleCredentials googleCredentials;
+
+    @Inject
+    GcpConfiguration gcpConfiguration;
+
+    @Produces
+    @Singleton
+    @Default
+    public SecretManagerServiceClient secretManagerClient() throws IOException {
+        SecretManagerServiceSettings.Builder builder = SecretManagerServiceSettings.newBuilder()
+                .setCredentialsProvider(() -> googleCredentials);
+
+        if (gcpConfiguration.projectId.isPresent()) {
+            builder.setQuotaProjectId(gcpConfiguration.projectId.get());
+        }
+
+        return SecretManagerServiceClient.create(builder.build());
+    }
+}


### PR DESCRIPTION
Add the Cloud Platform Auth Scope to enable access to Cloud APIs via service accounts. Add Secret Manager producer to demonstrate issue.

It seems like when using service accounts to authenticate, you need the extra step of calling the `.createScoped(..)` in certain cases. This "cloud-platform" scope comes from the [service account docs](https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam). We do this in our [Spring code](https://github.com/GoogleCloudPlatform/spring-cloud-gcp/blob/main/spring-cloud-gcp-core/src/main/java/com/google/cloud/spring/core/DefaultCredentialsProvider.java#L95) too.

I'm not sure why you need this when GCP already has the "IAM role" thing, but this was the only way I could get this sample to work. BTW, the service account needs to also have access to the secret via the "secret accessor role":

![image](https://user-images.githubusercontent.com/3209274/108131243-fe536300-707e-11eb-8df0-1a589184bbec.png)

If you remove the scope you will be able to reproduce the error when visiting `localhost:8080/secretmanager`.