### PR TITLE
Default project

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ They all share an optional common configuration property to set the project ID:
 quarkus.google.cloud.project-id=<your-project-id>
 ```
 
+If the project ID is not set, the extensions will default to using `ServiceOptions.getDefaultProjectId()` 
+that will use the default project detected via Application Default Credentials.
+
 All these extensions works with applications built as native image executables.
 
-These extension works well within the various Google Cloud Functions extensions available inside Quarkus as they directly authenticate via the built-in credentials.
+These extensions works well within the various Google Cloud Functions extensions available inside Quarkus as they directly authenticate via the built-in credentials.
 
 ## Authenticating to Google Cloud
 

--- a/bigquery/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigquery/runtime/BigQueryProducer.java
+++ b/bigquery/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigquery/runtime/BigQueryProducer.java
@@ -28,6 +28,8 @@ public class BigQueryProducer {
     @Default
     public BigQuery bigQuery() throws IOException {
         return BigQueryOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId.get()).build().getService();
+                .setProjectId(gcpConfiguration.projectId)
+                .build()
+                .getService();
     }
 }

--- a/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
+++ b/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
@@ -8,8 +8,6 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
 import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 
-import java.io.IOException;
-
 public class CommonBuildSteps {
 
     @BuildStep

--- a/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
+++ b/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
@@ -1,9 +1,14 @@
 package io.quarkiverse.googlecloudservices.common.deployment;
 
+import com.google.cloud.ServiceOptions;
+
 import io.quarkiverse.googlecloudservices.common.GcpCredentialProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
+
+import java.io.IOException;
 
 public class CommonBuildSteps {
 
@@ -15,5 +20,15 @@ public class CommonBuildSteps {
     @BuildStep
     public ExtensionSslNativeSupportBuildItem ssl() {
         return new ExtensionSslNativeSupportBuildItem("google-cloud-common");
+    }
+
+    @BuildStep
+    public RunTimeConfigurationDefaultBuildItem defaultProjectId() {
+        String defaultObject = ServiceOptions.getDefaultProjectId();
+        if (defaultObject != null) {
+            return new RunTimeConfigurationDefaultBuildItem("quarkus.google.cloud.project-id",
+                    ServiceOptions.getDefaultProjectId());
+        }
+        return null;
     }
 }

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -43,6 +43,10 @@
             <artifactId>google-cloud-graalvm-support</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>

--- a/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpConfiguration.java
+++ b/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpConfiguration.java
@@ -2,6 +2,8 @@ package io.quarkiverse.googlecloudservices.common;
 
 import java.util.Optional;
 
+import com.google.cloud.ServiceOptions;
+
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -10,9 +12,10 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class GcpConfiguration {
     /**
      * Google Cloud project ID.
+     * It defaults to `ServiceOptions.getDefaultProjectId()`, so to the project ID corresponding to the default credentials.
      */
     @ConfigItem
-    public Optional<String> projectId;
+    public String projectId;
 
     /**
      * Google Cloud service account file location.

--- a/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
+++ b/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
@@ -28,6 +28,8 @@ public class FirestoreProducer {
     @Default
     public Firestore firestore() throws IOException {
         return FirestoreOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId.get()).build().getService();
+                .setProjectId(gcpConfiguration.projectId)
+                .build()
+                .getService();
     }
 }

--- a/integration-tests/app-engine/README.md
+++ b/integration-tests/app-engine/README.md
@@ -15,10 +15,7 @@ echo "Hello World!" > hello.txt
 gsutil cp hello.txt gs://my-bucket
 ```
 
-Then you need to configure your Google Cloud project inside the `application.properties`:
-```
-quarkus.google.cloud.project-id=<my-propject-id>
-```
+As we plan to deploy to App Engine, we will not configure the project ID so that it will be taken automatically from the App Engine runtime.
 
 ## Deploying to Google App Engine
 

--- a/integration-tests/app-engine/src/main/resources/application.properties
+++ b/integration-tests/app-engine/src/main/resources/application.properties
@@ -1,3 +1,1 @@
-# Fill the following properties to run the application
-quarkus.google.cloud.project-id=
 quarkus.package.type=uber-jar

--- a/integration-tests/google-cloud-functions/README.md
+++ b/integration-tests/google-cloud-functions/README.md
@@ -15,10 +15,7 @@ echo "Hello World!" > hello.txt
 gsutil cp hello.txt gs://my-bucket
 ```
 
-Then you need to configure your Google Cloud project inside the `application.properties`:
-```
-quarkus.google.cloud.project-id=<my-propject-id>
-```
+As we plan to deploy to App Engine, we will not configure the project ID so that it will be taken automatically from the Cloud Functions runtime.
 
 ## Deploying to Google Cloud Functions
 
@@ -29,7 +26,7 @@ Then deploy the function to Google Cloud using:
 ```
 gcloud beta functions deploy quarkus-example-http \
   --entry-point=io.quarkus.gcp.functions.QuarkusHttpFunction \
-  --runtime=java11 --trigger-http --source=target/deployment
+  --runtime=java11 --trigger-http --source=target/deployment --allow-unauthenticated
 ```
 
-This command will give you as output a `httpsTrigger.url` that points to your function.
+This command will give you as output an `httpsTrigger.url` that points to your function.

--- a/integration-tests/google-cloud-functions/src/main/resources/application.properties
+++ b/integration-tests/google-cloud-functions/src/main/resources/application.properties
@@ -1,2 +1,0 @@
-# Fill the following properties to run the application
-quarkus.google.cloud.project-id=

--- a/integration-tests/main/README.md
+++ b/integration-tests/main/README.md
@@ -1,6 +1,6 @@
 # Quarkiverse - Google Cloud Services - Integration Tests - Main
 
-This is the main integration test, it allows to tests all Google Cloud services from REST endpoints using a service account authentication.
+This is the main integration test, it allows to test all Google Cloud services from REST endpoints using a service account authentication.
 
 It contains a test class that can be use to validate all services, this test is not run  by default.
 

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -1,8 +1,8 @@
-# Fill the following properties to run the application
+# You can set the following properties if you don't use the default credentials and project ID
 #quarkus.google.cloud.service-account-location=
-#quarkus.google.cloud.project-id=my-project-id
-quarkus.google.cloud.service-account-location=/data/dev/keys/methodical-mesh-238712-f1780e213891.json
-quarkus.google.cloud.project-id=methodical-mesh-238712
+#quarkus.google.cloud.project-id=
+
+# We use a dummy test projet id in test for the emulators to work
 %test.quarkus.google.cloud.project-id=test-project
 
 # Secret Manager Demo

--- a/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/SecretManagerProducer.java
+++ b/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/SecretManagerProducer.java
@@ -33,9 +33,7 @@ public class SecretManagerProducer {
         SecretManagerServiceSettings.Builder builder = SecretManagerServiceSettings.newBuilder()
                 .setCredentialsProvider(() -> googleCredentials);
 
-        if (gcpConfiguration.projectId.isPresent()) {
-            builder.setQuotaProjectId(gcpConfiguration.projectId.get());
-        }
+        builder.setQuotaProjectId(gcpConfiguration.projectId);
 
         return SecretManagerServiceClient.create(builder.build());
     }

--- a/spanner/runtime/src/main/java/io/quarkiverse/googlecloudservices/spanner/runtime/SpannerProducer.java
+++ b/spanner/runtime/src/main/java/io/quarkiverse/googlecloudservices/spanner/runtime/SpannerProducer.java
@@ -27,6 +27,8 @@ public class SpannerProducer {
     @Default
     public Spanner storage() throws IOException {
         return SpannerOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId.get()).build().getService();
+                .setProjectId(gcpConfiguration.projectId)
+                .build()
+                .getService();
     }
 }

--- a/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageProducer.java
+++ b/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageProducer.java
@@ -28,6 +28,8 @@ public class StorageProducer {
     @Default
     public Storage storage() throws IOException {
         return StorageOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId.get()).build().getService();
+                .setProjectId(gcpConfiguration.projectId)
+                .build()
+                .getService();
     }
 }


### PR DESCRIPTION
- Falback to default project ID from `ServiceOptions.getDefaultProjectId()` when no projectID is set inside `application.properties`.
- Use the default project ID in the various ITs