### PR TITLE
Allow Storage Host Configuration with Property

### DIFF
--- a/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/StorageResource.java
+++ b/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/StorageResource.java
@@ -13,7 +13,7 @@ import com.google.cloud.storage.Storage;
 
 @Path("/storage")
 public class StorageResource {
-    private static final String BUCKET = "quarkus-hello";
+    public static final String BUCKET = "quarkus-hello";
 
     @Inject
     Storage storage;

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -4,6 +4,7 @@
 
 # We use a dummy test projet id in test for the emulators to work
 %test.quarkus.google.cloud.project-id=test-project
+%test.quarkus.google.cloud.storage.host-override=http://localhost:8089
 
 # Secret Manager Demo
 # You can load secrets from Google Cloud Secret Manager with the ${sm//<SECRET_ID>} syntax.

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/StorageResourceTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/StorageResourceTest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.googlecloudservices.it;
+
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.Storage;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.parsing.Parser;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import javax.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import static io.restassured.RestAssured.given;
+
+@QuarkusTest
+public class StorageResourceTest {
+    private static final int PORT = 8089;
+
+    private static GenericContainer<?> GCLOUD_CONTAINER;
+
+    @Inject
+    Storage storage;
+
+    @BeforeAll
+    public static void startGcloudContainer() {
+        GCLOUD_CONTAINER = new GenericContainer<>(DockerImageName.parse("fsouza/fake-gcs-server"))
+                .withExposedPorts(4443)
+                .withCreateContainerCmdModifier(cmd -> {
+                    cmd.withEntrypoint("/bin/fake-gcs-server", "-scheme", "http", "-backend", "memory");
+                });
+        GCLOUD_CONTAINER.setPortBindings(Collections.singletonList(String.format("%d:%d", PORT, 4443)));
+        GCLOUD_CONTAINER.start();
+    }
+
+    @AfterAll
+    public static void stopGcloudContainer() {
+        if (GCLOUD_CONTAINER != null) {
+            GCLOUD_CONTAINER.stop();
+        }
+    }
+
+    @Test
+    public void testStorage() {
+        Bucket bucket = storage.get(StorageResource.BUCKET);
+        if (bucket == null) {
+            bucket = storage.create(BucketInfo.newBuilder(StorageResource.BUCKET).build());
+        }
+        bucket.create("hello.txt", "{\"success\": true}".getBytes(StandardCharsets.UTF_8));
+
+        RestAssured.registerParser("text/plain", Parser.JSON);
+        given()
+                .when().get("/storage")
+                .then()
+                .statusCode(200)
+                .body("success", Matchers.equalTo(true));
+    }
+}

--- a/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageConfiguration.java
+++ b/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageConfiguration.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.googlecloudservices.storage.runtime;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+@ConfigRoot(name = "google.cloud.storage", phase = ConfigPhase.RUN_TIME)
+public class StorageConfiguration {
+    /**
+     * Overrides the default service host.
+     * This is most commonly used for development or testing activities with a local Google Cloud Storage emulator instance.
+     */
+    @ConfigItem
+    public Optional<String> hostOverride;
+}

--- a/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageProducer.java
+++ b/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageProducer.java
@@ -1,18 +1,16 @@
 package io.quarkiverse.googlecloudservices.storage.runtime;
 
-import java.io.IOException;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import io.quarkiverse.googlecloudservices.common.GcpConfiguration;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.storage.Storage;
-import com.google.cloud.storage.StorageOptions;
-
-import io.quarkiverse.googlecloudservices.common.GcpConfiguration;
+import java.io.IOException;
 
 @ApplicationScoped
 public class StorageProducer {
@@ -23,13 +21,17 @@ public class StorageProducer {
     @Inject
     GcpConfiguration gcpConfiguration;
 
+    @Inject
+    StorageConfiguration storageConfiguration;
+
     @Produces
     @Singleton
     @Default
     public Storage storage() throws IOException {
-        return StorageOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId)
-                .build()
-                .getService();
+        StorageOptions.Builder builder = StorageOptions.newBuilder()
+                .setCredentials(googleCredentials)
+                .setProjectId(gcpConfiguration.projectId);
+        storageConfiguration.hostOverride.ifPresent(builder::setHost);
+        return builder.build().getService();
     }
 }


### PR DESCRIPTION
resolves #91

Sadly restrictToAnnotatedClass is not yet available (higher quarkus version?), if the global nature is a problem we could use QuarkusTestResources. But imo it's fine.

Google is a bit incosistent about the naming.

Client Library | Configure Endpoint
-- | --
Datastore | setHost(hostport)
Firestore | setHost(hostport)
Spanner | setEmulatorHost(hostport)
Pub/Sub | setChannelProvider with forTarget(hostport) / setEndpoint(endpoint)
Bigtable | setChannelProvider with forTarget(hostport) / setEndpoint(endpoint)

So for datastore I now went with `quarkus.google.cloud.storage.host-override`, similar to `quarkus.sqs.endpoint-override`.

Any feedback appreciated.
