### PR TITLE
Upgrade GCP GraalVM support version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
 
         <google-cloud-sdk.version>16.1.0</google-cloud-sdk.version>
-        <google-cloud-graalvm.version>0.3.0</google-cloud-graalvm.version>
+        <google-cloud-graalvm.version>0.4.0</google-cloud-graalvm.version>
         <!-- The Google Cloud BOM includes the 'android' version of Guava so we need to fix the 'jre' version.
         Make sure to keep these two libraries compatible. -->
         <guava.version>30.0-jre</guava.version>


### PR DESCRIPTION
Latest version 0.4.0 contains some bug fixes including delaying the initialization of `FirestoreImpl` referenced in #90.