### PR TITLE
Enforce dependencyConvergence

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -23,6 +23,10 @@
         <!-- The Google Cloud BOM includes the 'android' version of Guava so we need to fix the 'jre' version.
         Make sure to keep these two libraries compatible. -->
         <guava.version>30.0-jre</guava.version>
+        <opencensus.version>0.28.3</opencensus.version><!-- mess in google-pubsub and grpc deps; should be rather stable as OpenCensus has been sunsetted already - see https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/862 -->
+        <threeten.version>1.5.1</threeten.version><!-- mess in google-cloud-core transitive deps -->
+        <perfmark.version>0.23.0</perfmark.version><!-- mess in bigtable, firestore, pubsub, spanner and secret-manager transitive deps -->
+        <conscrypt.version>2.5.1</conscrypt.version><!-- mess in bigtable, firestore, pubsub, spanner and secret-manager transitive deps -->
     </properties>
 
     <dependencyManagement>
@@ -62,6 +66,28 @@
                 <groupId>io.quarkiverse.googlecloudservices</groupId>
                 <artifactId>quarkus-google-cloud-common-grpc</artifactId>
                 <version>${project.version}</version>
+            </dependency>
+
+            <!-- Dependency convergence fixes -->
+            <dependency>
+                <groupId>io.opencensus</groupId>
+                <artifactId>opencensus-api</artifactId>
+                <version>${opencensus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.perfmark</groupId>
+                <artifactId>perfmark-api</artifactId>
+                <version>${perfmark.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.threeten</groupId>
+                <artifactId>threetenbp</artifactId>
+                <version>${threeten.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.conscrypt</groupId>
+                <artifactId>conscrypt-openjdk-uber</artifactId>
+                <version>${conscrypt.version}</version>
             </dependency>
 
             <!-- Google Cloud Services Extensions -->

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <quarkus.version>2.0.0.CR3</quarkus.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <enforcer-plugin.version>3.0.0-M3</enforcer-plugin.version>
     </properties>
 
     <!-- Extension modules. Note that the integration-tests is added via profile to avoid releasing it -->
@@ -63,6 +64,16 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${enforcer-plugin.version}</version>
+                    <configuration>
+                        <rules>
+                            <dependencyConvergence/>
+                        </rules>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Enforcing dependency convergence is a good practice to bring more determinism into end user apps. We have been managing these versions in Camel Quarkus for a while but quarkus-google-cloud-services seems to be a much better place for it. 
threeten, perfmark and conscrypt could even go to `com.google.cloud:libraries-bom`.