### PR TITLE
Upgrade GraalVM native support to 0.5.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <google-cloud-sdk.version>16.1.0</google-cloud-sdk.version>
-        <google-cloud-graalvm.version>0.4.0</google-cloud-graalvm.version>
+        <google-cloud-graalvm.version>0.5.0</google-cloud-graalvm.version>
         <!-- The Google Cloud BOM includes the 'android' version of Guava so we need to fix the 'jre' version.
         Make sure to keep these two libraries compatible. -->
         <guava.version>30.0-jre</guava.version>


### PR DESCRIPTION
This version is compatible with GraalVM 21.2 that will be the new baseline for Quarkus 2.2