### PR TITLE
Make project ID opttional

### DIFF
--- a/bigquery/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigquery/runtime/BigQueryProducer.java
+++ b/bigquery/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigquery/runtime/BigQueryProducer.java
@@ -30,7 +30,7 @@ public class BigQueryProducer {
     public BigQuery bigQuery() throws IOException {
         GcpBootstrapConfiguration gcpConfiguration = gcpConfigHolder.getBootstrapConfig();
         return BigQueryOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId)
+                .setProjectId(gcpConfiguration.projectId.orElse(null))
                 .build()
                 .getService();
     }

--- a/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpBootstrapConfiguration.java
+++ b/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpBootstrapConfiguration.java
@@ -15,10 +15,11 @@ import io.quarkus.runtime.annotations.ConfigRoot;
 public class GcpBootstrapConfiguration {
     /**
      * Google Cloud project ID.
-     * It defaults to `ServiceOptions.getDefaultProjectId()`, so to the project ID corresponding to the default credentials.
+     * It defaults to `ServiceOptions.getDefaultProjectId()`,
+     * so to the project ID corresponding to the default credentials if the default credentials are set, otherwise null.
      */
-    @ConfigItem
-    public String projectId;
+    @ConfigItem(defaultValueDocumentation = "ServiceOptions.getDefaultProjectId()")
+    public Optional<String> projectId;
 
     /**
      * Google Cloud service account file location.

--- a/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
+++ b/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
@@ -30,7 +30,7 @@ public class FirestoreProducer {
     public Firestore firestore() throws IOException {
         GcpBootstrapConfiguration gcpConfiguration = gcpConfigHolder.getBootstrapConfig();
         return FirestoreOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId)
+                .setProjectId(gcpConfiguration.projectId.orElse(null))
                 .build()
                 .getService();
     }

--- a/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/SecretManagerProducer.java
+++ b/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/SecretManagerProducer.java
@@ -36,7 +36,7 @@ public class SecretManagerProducer {
         SecretManagerServiceSettings.Builder builder = SecretManagerServiceSettings.newBuilder()
                 .setCredentialsProvider(() -> googleCredentials);
 
-        builder.setQuotaProjectId(gcpConfiguration.projectId);
+        builder.setQuotaProjectId(gcpConfiguration.projectId.orElse(null));
 
         return SecretManagerServiceClient.create(builder.build());
     }

--- a/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/config/SecretManagerConfigSourceProvider.java
+++ b/secret-manager/runtime/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/config/SecretManagerConfigSourceProvider.java
@@ -14,7 +14,7 @@ public class SecretManagerConfigSourceProvider implements ConfigSourceProvider {
     private final String projectId;
 
     public SecretManagerConfigSourceProvider(GcpBootstrapConfiguration gcpBootstrapConfiguration) {
-        this.projectId = gcpBootstrapConfiguration.projectId;
+        this.projectId = gcpBootstrapConfiguration.projectId.orElse(null);
     }
 
     @Override

--- a/spanner/runtime/src/main/java/io/quarkiverse/googlecloudservices/spanner/runtime/SpannerProducer.java
+++ b/spanner/runtime/src/main/java/io/quarkiverse/googlecloudservices/spanner/runtime/SpannerProducer.java
@@ -29,7 +29,7 @@ public class SpannerProducer {
     public Spanner storage() throws IOException {
         GcpBootstrapConfiguration gcpConfiguration = gcpConfigHolder.getBootstrapConfig();
         return SpannerOptions.newBuilder().setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId)
+                .setProjectId(gcpConfiguration.projectId.orElse(null))
                 .build()
                 .getService();
     }

--- a/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageProducer.java
+++ b/storage/runtime/src/main/java/io/quarkiverse/googlecloudservices/storage/runtime/StorageProducer.java
@@ -34,7 +34,7 @@ public class StorageProducer {
         GcpBootstrapConfiguration gcpConfiguration = gcpConfigHolder.getBootstrapConfig();
         StorageOptions.Builder builder = StorageOptions.newBuilder()
                 .setCredentials(googleCredentials)
-                .setProjectId(gcpConfiguration.projectId);
+                .setProjectId(gcpConfiguration.projectId.orElse(null));
         storageConfiguration.hostOverride.ifPresent(builder::setHost);
         return builder.build().getService();
     }


### PR DESCRIPTION
Fixes #150

@ppalaga can you test this PR to see if it allows to avoid duplicating the projectId between the application.properties and the route ?
I'm curious about how it interact with the default value provided via `ServiceOptions.getDefaultProjectId()` inside our build steps.