### PR TITLE
Use updated google native-image-support artifact

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <google-cloud-sdk.version>21.0.0</google-cloud-sdk.version>
-        <google-cloud-graalvm.version>0.6.0</google-cloud-graalvm.version>
+        <google-native-image-support.version>0.8.0</google-native-image-support.version>
         <!-- Dependency convergence issues -->
         <opencensus.version>0.28.3</opencensus.version><!-- mess in google-pubsub and grpc deps; should be rather stable as OpenCensus has been sunsetted already - see https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/862 -->
         <threeten.version>1.5.1</threeten.version><!-- mess in google-cloud-core transitive deps -->
@@ -37,8 +37,8 @@
             </dependency>
             <dependency>
                 <groupId>com.google.cloud</groupId>
-                <artifactId>google-cloud-graalvm-support</artifactId>
-                <version>${google-cloud-graalvm.version}</version>
+                <artifactId>native-image-support</artifactId>
+                <version>${google-native-image-support.version}</version>
             </dependency>
 
             <!-- Google Cloud Services common libs-->

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
-            <artifactId>google-cloud-graalvm-support</artifactId>
+            <artifactId>native-image-support</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
Hey Loic,

We recently renamed our project `google-cloud-graalvm-support` to `native-image-support` to be more in-line with existing conventions that others have adopted. Updated github repo: https://github.com/GoogleCloudPlatform/native-image-support-java

This PR updates the project to use the new `native-image-support` artifact.