### PR TITLE
Use RESTEasy Reactive as REST implementation in docs and tests

### DIFF
--- a/docs/modules/ROOT/pages/bigquery.adoc
+++ b/docs/modules/ROOT/pages/bigquery.adoc
@@ -13,7 +13,7 @@ First, we need a new project. Create a new project with the following command (r
 mvn io.quarkus:quarkus-maven-plugin:${quarkusVersion}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=bigquery-quickstart \
-    -Dextensions="resteasy-jackson,quarkus-google-cloud-bigquery"
+    -Dextensions="resteasy-reactive-jackson,quarkus-google-cloud-bigquery"
 cd bigquery-quickstart
 ----
 

--- a/docs/modules/ROOT/pages/bigtable.adoc
+++ b/docs/modules/ROOT/pages/bigtable.adoc
@@ -13,7 +13,7 @@ First, we need a new project. Create a new project with the following command (r
 mvn io.quarkus:quarkus-maven-plugin:<quarkusVersion>:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=pubsub-quickstart \
-    -Dextensions="resteasy-jackson,quarkus-google-cloud-bigtable"
+    -Dextensions="resteasy-reactive-jackson,quarkus-google-cloud-bigtable"
 cd pubsub-quickstart
 ----
 

--- a/docs/modules/ROOT/pages/firestore.adoc
+++ b/docs/modules/ROOT/pages/firestore.adoc
@@ -13,7 +13,7 @@ First, we need a new project. Create a new project with the following command (r
 mvn io.quarkus:quarkus-maven-plugin:<quarkusVersion>:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=firestore-quickstart \
-    -Dextensions="resteasy-jackson,quarkus-google-cloud-firestore"
+    -Dextensions="resteasy-reactive-jackson,quarkus-google-cloud-firestore"
 cd firestore-quickstart
 ----
 

--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -13,7 +13,7 @@ First, we need a new project.Create a new project with the following command (re
 mvn io.quarkus:quarkus-maven-plugin:<quarkusVersion>:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=pubsub-quickstart \
-    -Dextensions="resteasy-jackson,quarkus-google-cloud-pubsub"
+    -Dextensions="resteasy-reactive-jackson,quarkus-google-cloud-pubsub"
 cd pubsub-quickstart
 ----
 

--- a/docs/modules/ROOT/pages/secretmanager.adoc
+++ b/docs/modules/ROOT/pages/secretmanager.adoc
@@ -15,7 +15,7 @@ First, we need a new project.Create a new project with the following command (re
 mvn io.quarkus:quarkus-maven-plugin:${quarkusVersion}:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=secretmanager-quickstart \
-    -Dextensions="resteasy-jackson,quarkus-google-cloud-secret-manager"
+    -Dextensions="resteasy-reactive-jackson,quarkus-google-cloud-secret-manager"
 cd secretmanager-quickstart
 ----
 

--- a/docs/modules/ROOT/pages/spanner.adoc
+++ b/docs/modules/ROOT/pages/spanner.adoc
@@ -13,7 +13,7 @@ First, we need a new project.Create a new project with the following command (re
 mvn io.quarkus:quarkus-maven-plugin:<quarkusVersion>:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=spanner-quickstart \
-    -Dextensions="resteasy-jackson,quarkus-google-cloud-spanner"
+    -Dextensions="resteasy-reactive-jackson,quarkus-google-cloud-spanner"
 cd spanner-quickstart
 ----
 

--- a/docs/modules/ROOT/pages/storage.adoc
+++ b/docs/modules/ROOT/pages/storage.adoc
@@ -13,7 +13,7 @@ First, we need a new project.Create a new project with the following command (re
 mvn io.quarkus:quarkus-maven-plugin:<quarkusVersion>:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=bigquery-quickstart \
-    -Dextensions="resteasy-jackson,quarkus-google-cloud-storage"
+    -Dextensions="resteasy-reactive-jackson,quarkus-google-cloud-storage"
 cd storage-quickstart
 ----
 

--- a/integration-tests/app-engine/pom.xml
+++ b/integration-tests/app-engine/pom.xml
@@ -21,7 +21,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy</artifactId>
+      <artifactId>quarkus-resteasy-reactive</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.googlecloudservices</groupId>

--- a/integration-tests/main/pom.xml
+++ b/integration-tests/main/pom.xml
@@ -18,11 +18,7 @@
   <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jsonb</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jackson</artifactId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This is part of the ongoing effort of pushing RESTEasy Reactive as the
default implementation for Quarkus 2.8.