### PR TITLE
Support both GraalVM 22.2 and 22.3

### DIFF
--- a/common/grpc/pom.xml
+++ b/common/grpc/pom.xml
@@ -50,9 +50,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--
+            On GraalVM 22.3, the substitution annotations will be on the graal-sdk lib, so we add both lib here
+            to be able to support 22.2 and 22.3.
+        -->
         <dependency>
             <groupId>org.graalvm.nativeimage</groupId>
             <artifactId>svm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
On 22.3, the substitution annotations have been moved from the svm lib to the graal-sdk lib.