### PR TITLE
Add Firebase Admin to README and nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You can find the documentation in the [Google Cloud Services Quarkiverse documen
 The following services are implemented:
 - [BigQuery](bigquery)
 - [Bigtable](bigtable)
+- [Firebase Admin](firebase-admin)
 - [Firestore](firestore)
 - [PubSub](pubsub)
 - [Secret Manager](secret-manager)
@@ -25,6 +26,7 @@ Example applications can be found inside the integration-test folder:
 - [main](integration-tests/main): RESTEasy endpoints using all the Google Cloud Services extensions, to be deployed as a standalone JAR.
 - [google-cloud-functions](integration-tests/google-cloud-functions): A Google Cloud HTTP function using Google Cloud Storage. 
 - [app-engine](integration-tests/app-engine): A RESTEasy endpoint using Google Cloud Storage, to be deployed inside Google App Engine.
+- [firebase-admin](integration-tests/firebase-admin): RESTEasy endpoints using Firebase Admin SDK features, such as user management.
     
 ## Contributing
 

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -4,6 +4,7 @@
 ** xref:index.adoc#examples[Example applications]
 * xref:bigquery.adoc[BigQuery]
 * xref:bigtable.adoc[BigTable]
+* xref:firebase-admin.adoc[Firebase Admin]
 * xref:firestore.adoc[Firestore]
 * xref:pubsub.adoc[PubSub]
 * xref:secretmanager.adoc[SecretManager]


### PR DESCRIPTION
Hello @loicmathieu. I have just noticed that in #336, I had forgotten to list Firebase Admin both in the README and in the docs navbar. I'm sorry about that. This PR aims to improve the docs only.