### PR TITLE
Add option to specify retry settings for Firestore

### DIFF
--- a/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreConfiguration.java
+++ b/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreConfiguration.java
@@ -1,7 +1,11 @@
 package io.quarkiverse.googlecloudservices.firestore.runtime;
 
+import java.time.Duration;
 import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
 
+import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -14,4 +18,63 @@ public class FirestoreConfiguration {
      */
     @ConfigItem
     public Optional<String> hostOverride;
+
+    /**
+     * Controls the retry settings for Firestore requests.
+     */
+    @ConfigItem
+    public Optional<RetryConfiguration> retry;
+
+    @ConfigGroup
+    public static class RetryConfiguration {
+
+        /**
+         * Total timeout for all retries.
+         */
+        @ConfigItem
+        public Optional<Duration> totalTimeout;
+
+        /**
+         * Delay before the first retry.
+         */
+        @ConfigItem
+        public Optional<Duration> initialRetryDelay;
+
+        /**
+         * Controls the rate of change of the delay. Next retry is multiplied by this factor.
+         */
+        @ConfigItem
+        public OptionalDouble retryDelayMultiplier;
+
+        /**
+         * Limits the maximum retry delay.
+         */
+        @ConfigItem
+        public Optional<Duration> maxRetryDelay;
+
+        /**
+         * Determines the maximum number of attempts. When number of attempts reach this limit they stop retrying.
+         */
+        @ConfigItem
+        public OptionalInt maxAttempts;
+
+        /**
+         * Timeout for the initial RPC.
+         */
+        @ConfigItem
+        public Optional<Duration> initialRpcTimeout;
+
+        /**
+         * Controls the rate of change of the RPC timeout. Next timeout is multiplied by this factor.
+         */
+        @ConfigItem
+        public OptionalDouble rpcTimeoutMultiplier;
+
+        /**
+         * Limits the maximum RPC timeout.
+         */
+        @ConfigItem
+        public Optional<Duration> maxRpcTimeout;
+    }
+
 }

--- a/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
+++ b/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
@@ -8,12 +8,16 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.threeten.bp.Duration;
+
+import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 
 import io.quarkiverse.googlecloudservices.common.GcpBootstrapConfiguration;
 import io.quarkiverse.googlecloudservices.common.GcpConfigHolder;
+import io.quarkiverse.googlecloudservices.firestore.runtime.FirestoreConfiguration.RetryConfiguration;
 
 @ApplicationScoped
 public class FirestoreProducer {
@@ -32,10 +36,35 @@ public class FirestoreProducer {
     @Default
     public Firestore firestore() throws IOException {
         GcpBootstrapConfiguration gcpConfiguration = gcpConfigHolder.getBootstrapConfig();
-        FirestoreOptions.Builder builder = FirestoreOptions.newBuilder().setCredentials(googleCredentials)
+        FirestoreOptions.Builder builder = FirestoreOptions.newBuilder()
+                .setCredentials(googleCredentials)
                 .setProjectId(gcpConfiguration.projectId.orElse(null));
         firestoreConfiguration.hostOverride.ifPresent(builder::setHost);
-
+        firestoreConfiguration.retry.ifPresent(retry -> builder.setRetrySettings(buildRetrySettings(retry)));
         return builder.build().getService();
     }
+
+    private RetrySettings buildRetrySettings(RetryConfiguration retryConfiguration) {
+        RetrySettings.Builder retrySettingsBuilder = RetrySettings.newBuilder();
+        retryConfiguration.totalTimeout.ifPresent(d -> retrySettingsBuilder.setTotalTimeout(convertDuration(d)));
+        retryConfiguration.initialRetryDelay.ifPresent(d -> retrySettingsBuilder.setInitialRetryDelay(convertDuration(d)));
+        retryConfiguration.retryDelayMultiplier.ifPresent(retrySettingsBuilder::setRetryDelayMultiplier);
+        retryConfiguration.maxRetryDelay.ifPresent(d -> retrySettingsBuilder.setMaxRetryDelay(convertDuration(d)));
+        retryConfiguration.maxAttempts.ifPresent(retrySettingsBuilder::setMaxAttempts);
+        retryConfiguration.initialRpcTimeout.ifPresent(d -> retrySettingsBuilder.setInitialRpcTimeout(convertDuration(d)));
+        retryConfiguration.rpcTimeoutMultiplier.ifPresent(retrySettingsBuilder::setRpcTimeoutMultiplier);
+        retryConfiguration.maxRpcTimeout.ifPresent(d -> retrySettingsBuilder.setMaxRpcTimeout(convertDuration(d)));
+        return retrySettingsBuilder.build();
+    }
+
+    /**
+     * Converts java.time.Duration to org.threeten.bp.Duration used by Firestore
+     *
+     * @param duration deserialized from configuration
+     * @return transformed Duration that is accepted by Firestore
+     */
+    private Duration convertDuration(java.time.Duration duration) {
+        return Duration.ofMillis(duration.toMillis());
+    }
+
 }


### PR DESCRIPTION
This PR adds options to specify custom retry settings for Firestore.
Users can now configure Firestore retry settings through `application.properties` file. Change was tested with simple Quarkus app and I was able to change retry settings with:
```
quarkus.google.cloud.firestore.retry.max-retry-delay=1M
quarkus.google.cloud.firestore.retry.initial-retry-delay=2S
quarkus.google.cloud.firestore.retry.max-attempts=10
```