### PR TITLE
Introduce GcpConfigurationDoneBuildItem to order build steps

### DIFF
--- a/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
+++ b/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/CommonBuildSteps.java
@@ -9,6 +9,7 @@ import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Produce;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.BootstrapConfigSetupCompleteBuildItem;
 import io.quarkus.deployment.builditem.ExtensionSslNativeSupportBuildItem;
@@ -31,6 +32,7 @@ public class CommonBuildSteps {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     @Consume(BootstrapConfigSetupCompleteBuildItem.class)
+    @Produce(GcpConfigurationDoneBuildItem.class)
     public void configure(GcpCredentialRecorder recorder, GcpBootstrapConfiguration bootstrapConfiguration) {
         recorder.configure(bootstrapConfiguration);
     }

--- a/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/GcpConfigurationDoneBuildItem.java
+++ b/common/deployment/src/main/java/io/quarkiverse/googlecloudservices/common/deployment/GcpConfigurationDoneBuildItem.java
@@ -1,0 +1,6 @@
+package io.quarkiverse.googlecloudservices.common.deployment;
+
+import io.quarkus.builder.item.EmptyBuildItem;
+
+public final class GcpConfigurationDoneBuildItem extends EmptyBuildItem {
+}

--- a/secret-manager/deployment/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/deployment/SecretManagerBuildSteps.java
+++ b/secret-manager/deployment/src/main/java/io/quarkiverse/googlecloudservices/secretmanager/deployment/SecretManagerBuildSteps.java
@@ -1,10 +1,12 @@
 package io.quarkiverse.googlecloudservices.secretmanager.deployment;
 
 import io.quarkiverse.googlecloudservices.common.GcpBootstrapConfiguration;
+import io.quarkiverse.googlecloudservices.common.deployment.GcpConfigurationDoneBuildItem;
 import io.quarkiverse.googlecloudservices.secretmanager.runtime.SecretManagerProducer;
 import io.quarkiverse.googlecloudservices.secretmanager.runtime.SecretManagerRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Consume;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
@@ -25,6 +27,7 @@ public class SecretManagerBuildSteps {
 
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
+    @Consume(GcpConfigurationDoneBuildItem.class)
     public RunTimeConfigurationSourceValueBuildItem configure(SecretManagerRecorder recorder,
             GcpBootstrapConfiguration bootstrapConfiguration) {
         return new RunTimeConfigurationSourceValueBuildItem(


### PR DESCRIPTION
This should force common build steps to be executed before secret manager build steps and fixes #358 