### PR TITLE
Update README.md of Firebase Admin

### DIFF
--- a/firebase-admin/README.md
+++ b/firebase-admin/README.md
@@ -2,4 +2,4 @@
 
 This extension allows to inject a `com.google.firebase.auth.FirebaseAuth` object inside your Quarkus application.
 
-You can find the documentation in the [Firebase Admin Quarkiverse documentation site](https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/firebase.html).
+You can find the documentation in the [Firebase Admin Quarkiverse documentation site](https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/firebase-admin.html).


### PR DESCRIPTION
Updated invalid link to docs in README of firebase-admin. The current link leads to a 404 page.