### PR TITLE
feature(devservices): added pubsub dev service

### DIFF
--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -203,7 +203,7 @@ If we want to connect to the Dev Service, we need to specify `TransportChannelPr
 
 We can just reuse the code from the previous example and add the `TransportChannelProvider` to the `Subscriber` and `Publisher`. So what do we need to change?
 
-As a first thing we should declare variable which we can then reuse:
+As a first thing, we should declare a variable which we can then reuse:
 
 [source,java]
 ----

--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -199,149 +199,18 @@ You can also set the
 
 === Using the Dev Service
 
-If we want to connect to the Dev Service, we need to specify `ChannelProvider` when creating subscription and publisher.
+If we want to connect to the Dev Service, we need to specify `TransportChannelProvider` when creating subscription and publisher.
 
-For this example, we will use the code from the previous example, and we will add a `ChannelProvider` to the `Publisher` and `Subscriber` builders.
+We can just reuse the code from the previous example and add the `TransportChannelProvider` to the `Subscriber` and `Publisher`. So what do we need to change?
+
+As a first thing we should declare variable which we can then reuse:
 
 [source,java]
 ----
-import java.io.IOException;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.StreamSupport;
-
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
-
-import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutureCallback;
-import com.google.api.core.ApiFutures;
-import com.google.api.gax.core.CredentialsProvider;
-import com.google.api.gax.grpc.GrpcTransportChannel;
-import com.google.api.gax.rpc.FixedTransportChannelProvider;
-import com.google.api.gax.rpc.TransportChannelProvider;
-import com.google.cloud.pubsub.v1.MessageReceiver;
-import com.google.cloud.pubsub.v1.Publisher;
-import com.google.cloud.pubsub.v1.Subscriber;
-import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
-import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
-import com.google.common.util.concurrent.MoreExecutors;
-import com.google.protobuf.ByteString;
-import com.google.pubsub.v1.ProjectName;
-import com.google.pubsub.v1.ProjectSubscriptionName;
-import com.google.pubsub.v1.PubsubMessage;
-import com.google.pubsub.v1.PushConfig;
-import com.google.pubsub.v1.Subscription;
-import com.google.pubsub.v1.Topic;
-import com.google.pubsub.v1.TopicName;
-
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
-
-@Path("/pubsub")
-public class PubSubResource {
-    private static final Logger LOG = Logger.getLogger(PubSubResource.class);
-
-    @ConfigProperty(name = "quarkus.google.cloud.project-id")
-    String projectId;// Inject the projectId property from application.properties
-
-    private TopicName topicName;
-    private Subscriber subscriber;
-
-    @Inject
-    CredentialsProvider credentialsProvider;
-
-    private TransportChannelProvider channelProvider;
-
-    @PostConstruct
-    void init() throws IOException {
-        // Create a ChannelProvider that connects to the Dev Service
-        ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:8085").usePlaintext().build();
-        channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
-
-        // Init topic and subscription, the topic must have been created before
-        topicName = TopicName.of(projectId, "test-topic");
-        ProjectSubscriptionName subscriptionName = initSubscription();
-
-        // Subscribe to PubSub
-        MessageReceiver receiver = (message, consumer) -> {
-            LOG.infov("Got message {0}", message.getData().toStringUtf8());
-            consumer.ack();
-        };
-
-        // Create a subscriber and set the ChannelProvider
-        subscriber = Subscriber.newBuilder(subscriptionName, receiver).setChannelProvider(channelProvider).build();
-        subscriber.startAsync().awaitRunning();
-    }
-
-    @PreDestroy
-    void destroy() {
-        // Stop the subscription at destroy time
-        if (subscriber != null) {
-            subscriber.stopAsync();
-        }
-    }
-
-    @GET
-    @Produces(MediaType.TEXT_PLAIN)
-    public void pubsub() throws IOException, InterruptedException {
-        // Init a publisher to the topic
-        Publisher publisher = Publisher.newBuilder(topicName)
-                .setCredentialsProvider(credentialsProvider)
-                // Set the ChannelProvider
-                .setChannelProvider(channelProvider)
-                .build();
-        try {
-            ByteString data = ByteString.copyFromUtf8("my-message");// Create a new message
-            PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
-            ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);// Publish the message
-            ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {// Wait for message submission and log the result
-                public void onSuccess(String messageId) {
-                    LOG.infov("published with message id {0}", messageId);
-                }
-
-                public void onFailure(Throwable t) {
-                    LOG.warnv("failed to publish: {0}", t);
-                }
-            }, MoreExecutors.directExecutor());
-        } finally {
-            publisher.shutdown();
-            publisher.awaitTermination(1, TimeUnit.MINUTES);
-        }
-    }
-
-    private ProjectSubscriptionName initSubscription() throws IOException {
-        // List all existing subscriptions and create the 'test-subscription' if needed
-        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, "test-subscription");
-        SubscriptionAdminSettings subscriptionAdminSettings = SubscriptionAdminSettings.newBuilder()
-                .setCredentialsProvider(credentialsProvider)
-                // Set the ChannelProvider
-                .setTransportChannelProvider(channelProvider)
-                .build();
-
-        try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create(subscriptionAdminSettings)) {
-            Iterable<Subscription> subscriptions = subscriptionAdminClient.listSubscriptions(ProjectName.of(projectId))
-                    .iterateAll();
-            Optional<Subscription> existing = StreamSupport.stream(subscriptions.spliterator(), false)
-                    .filter(sub -> sub.getName().equals(subscriptionName.toString()))
-                    .findFirst();
-            if (existing.isEmpty()) {
-                subscriptionAdminClient.createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
-            }
-        }
-        return subscriptionName;
-    }
-}
+private TransportChannelProvider channelProvider;
 ----
 
-So what did we changed? Firstly, we created a TransportChannelProvider that provides connection to devservice within the `init` method:
+Then, we can create a `TransportChannelProvider` that provides connection to devservice within the `init` method:
 
 [source,java]
 ----
@@ -350,7 +219,7 @@ ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:8085").usePl
 channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
 ----
 
-Then when creating the `Subscriber` we set the `ChannelProvider`:
+Also in the same method when creating the `Subscriber` we set the `TransportChannelProvider`:
 
 [source,java]
 ----
@@ -371,7 +240,7 @@ Publisher publisher = Publisher.newBuilder(topicName)
 .build();
 ----
 
-And finally we also set the `ChannelProvider` when creating the `SubscriptionAdminClient` in the `initSubscription` method:
+And finally we also set the `TransportChannelProvider` when creating the `SubscriptionAdminClient` in the `initSubscription` method:
 
 [source,java]
 ----

--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -199,7 +199,7 @@ You can also set the
 
 === Using the Dev Service
 
-If we want to connect to the Dev Service, we need to specify `TransportChannelProvider` when creating subscription and publisher.
+If we want to connect to the Dev Service, we need to specify `TransportChannelProvider` when creating subscriptions and publishers.
 
 We can just reuse the code from the previous example and add the `TransportChannelProvider` to the `Subscriber` and `Publisher`. So what do we need to change?
 

--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -195,7 +195,7 @@ The extension provides a Dev Service that can be used to run a local PubSub emul
 
 You can also set the
 
-* `quarkus.google.cloud.pubsub.devservice.port` property to change the port on which the emulator will be started (default is `8085`).
+* `quarkus.google.cloud.pubsub.devservice.port` property to change the port on which the emulator will be started (by default there is no port set, so the emulator will use a random port)
 
 === Using the Dev Service
 
@@ -341,7 +341,7 @@ public class PubSubResource {
 }
 ----
 
-So what did we change? First we created a `TransportChannelProvider` that connects to the Dev Service in the `init` method:
+So what did we changed? Firstly, we created a TransportChannelProvider that provides connection to devservice within the `init` method:
 
 [source,java]
 ----

--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -184,3 +184,200 @@ public class PubSubResource {
     }
 }
 ----
+
+== Dev Service
+
+=== Configuring the Dev Service
+
+The extension provides a Dev Service that can be used to run a local PubSub emulator. This is useful for testing purposes, so you don't have to rely on a real PubSub instance. By default, the Dev Service is disabled, but you can enable it by setting the
+
+* `quarkus.google.cloud.pubsub.devservice.enabled` property to `true`
+
+You can also set the
+
+* `quarkus.google.cloud.pubsub.devservice.port` property to change the port on which the emulator will be started (default is `8085`).
+
+=== Using the Dev Service
+
+If we want to connect to the Dev Service, we need to specify `ChannelProvider` when creating subscription and publisher.
+
+For this example, we will use the code from the previous example, and we will add a `ChannelProvider` to the `Publisher` and `Subscriber` builders.
+
+[source,java]
+----
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.grpc.GrpcTransportChannel;
+import com.google.api.gax.rpc.FixedTransportChannelProvider;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.ProjectName;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PubsubMessage;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.Subscription;
+import com.google.pubsub.v1.Topic;
+import com.google.pubsub.v1.TopicName;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+@Path("/pubsub")
+public class PubSubResource {
+    private static final Logger LOG = Logger.getLogger(PubSubResource.class);
+
+    @ConfigProperty(name = "quarkus.google.cloud.project-id")
+    String projectId;// Inject the projectId property from application.properties
+
+    private TopicName topicName;
+    private Subscriber subscriber;
+
+    @Inject
+    CredentialsProvider credentialsProvider;
+
+    private TransportChannelProvider channelProvider;
+
+    @PostConstruct
+    void init() throws IOException {
+        // Create a ChannelProvider that connects to the Dev Service
+        ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:8085").usePlaintext().build();
+        channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+
+        // Init topic and subscription, the topic must have been created before
+        topicName = TopicName.of(projectId, "test-topic");
+        ProjectSubscriptionName subscriptionName = initSubscription();
+
+        // Subscribe to PubSub
+        MessageReceiver receiver = (message, consumer) -> {
+            LOG.infov("Got message {0}", message.getData().toStringUtf8());
+            consumer.ack();
+        };
+
+        // Create a subscriber and set the ChannelProvider
+        subscriber = Subscriber.newBuilder(subscriptionName, receiver).setChannelProvider(channelProvider).build();
+        subscriber.startAsync().awaitRunning();
+    }
+
+    @PreDestroy
+    void destroy() {
+        // Stop the subscription at destroy time
+        if (subscriber != null) {
+            subscriber.stopAsync();
+        }
+    }
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public void pubsub() throws IOException, InterruptedException {
+        // Init a publisher to the topic
+        Publisher publisher = Publisher.newBuilder(topicName)
+                .setCredentialsProvider(credentialsProvider)
+                // Set the ChannelProvider
+                .setChannelProvider(channelProvider)
+                .build();
+        try {
+            ByteString data = ByteString.copyFromUtf8("my-message");// Create a new message
+            PubsubMessage pubsubMessage = PubsubMessage.newBuilder().setData(data).build();
+            ApiFuture<String> messageIdFuture = publisher.publish(pubsubMessage);// Publish the message
+            ApiFutures.addCallback(messageIdFuture, new ApiFutureCallback<String>() {// Wait for message submission and log the result
+                public void onSuccess(String messageId) {
+                    LOG.infov("published with message id {0}", messageId);
+                }
+
+                public void onFailure(Throwable t) {
+                    LOG.warnv("failed to publish: {0}", t);
+                }
+            }, MoreExecutors.directExecutor());
+        } finally {
+            publisher.shutdown();
+            publisher.awaitTermination(1, TimeUnit.MINUTES);
+        }
+    }
+
+    private ProjectSubscriptionName initSubscription() throws IOException {
+        // List all existing subscriptions and create the 'test-subscription' if needed
+        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(projectId, "test-subscription");
+        SubscriptionAdminSettings subscriptionAdminSettings = SubscriptionAdminSettings.newBuilder()
+                .setCredentialsProvider(credentialsProvider)
+                // Set the ChannelProvider
+                .setTransportChannelProvider(channelProvider)
+                .build();
+
+        try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create(subscriptionAdminSettings)) {
+            Iterable<Subscription> subscriptions = subscriptionAdminClient.listSubscriptions(ProjectName.of(projectId))
+                    .iterateAll();
+            Optional<Subscription> existing = StreamSupport.stream(subscriptions.spliterator(), false)
+                    .filter(sub -> sub.getName().equals(subscriptionName.toString()))
+                    .findFirst();
+            if (existing.isEmpty()) {
+                subscriptionAdminClient.createSubscription(subscriptionName, topicName, PushConfig.getDefaultInstance(), 0);
+            }
+        }
+        return subscriptionName;
+    }
+}
+----
+
+So what did we change? First we created a `TransportChannelProvider` that connects to the Dev Service in the `init` method:
+
+[source,java]
+----
+// Create a ChannelProvider that connects to the Dev Service
+ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:8085").usePlaintext().build();
+channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
+----
+
+Then when creating the `Subscriber` we set the `ChannelProvider`:
+
+[source,java]
+----
+// Create a subscriber and set the ChannelProvider
+subscriber = Subscriber.newBuilder(subscriptionName, receiver).setChannelProvider(channelProvider).build();
+subscriber.startAsync().awaitRunning();
+----
+
+The same is done when creating the `Publisher` in the `pubsub` method:
+
+[source,java]
+----
+// Init a publisher to the topic
+Publisher publisher = Publisher.newBuilder(topicName)
+.setCredentialsProvider(credentialsProvider)
+// Set the ChannelProvider
+.setChannelProvider(channelProvider)
+.build();
+----
+
+And finally we also set the `ChannelProvider` when creating the `SubscriptionAdminClient` in the `initSubscription` method:
+
+[source,java]
+----
+SubscriptionAdminSettings subscriptionAdminSettings = SubscriptionAdminSettings.newBuilder()
+.setCredentialsProvider(credentialsProvider)
+// Set the ChannelProvider
+.setTransportChannelProvider(channelProvider)
+.build();
+----

--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -203,10 +203,13 @@ If we want to connect to the Dev Service, we need to specify `TransportChannelPr
 
 We can just reuse the code from the previous example and add the `TransportChannelProvider` to the `Subscriber` and `Publisher`. So what do we need to change?
 
-As a first thing, we should declare a variable which we can then reuse:
+As a first thing, we should declare a variable which we can then reuse and also inject the `quarkus.google.cloud.pubsub.emulator-host` property:
 
 [source,java]
 ----
+@ConfigProperty(name = "quarkus.google.cloud.pubsub.emulator-host")
+String emulatorHost;
+
 private TransportChannelProvider channelProvider;
 ----
 
@@ -215,7 +218,7 @@ Then, we can create a `TransportChannelProvider` that provides connection to dev
 [source,java]
 ----
 // Create a ChannelProvider that connects to the Dev Service
-ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:8085").usePlaintext().build();
+ManagedChannel channel = ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
 channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel));
 ----
 

--- a/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/pubsub/TopicManager.java
+++ b/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/pubsub/TopicManager.java
@@ -31,6 +31,9 @@ public class TopicManager {
     @ConfigProperty(name = "pubsub.use-emulator", defaultValue = "false")
     boolean useEmulator;
 
+    @ConfigProperty(name = "quarkus.google.cloud.pubsub.emulator-host")
+    String emulatorHost;
+
     private TopicName topicName;
     private Optional<TransportChannelProvider> channelProvider;
 
@@ -39,7 +42,7 @@ public class TopicManager {
         this.topicName = TopicName.of(projectId, "test-topic");
 
         if (useEmulator) {
-            ManagedChannel channel = ManagedChannelBuilder.forTarget("localhost:8085").usePlaintext().build();
+            ManagedChannel channel = ManagedChannelBuilder.forTarget(emulatorHost).usePlaintext().build();
             channelProvider = Optional.of(FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel)));
         } else {
             channelProvider = Optional.empty();

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -14,7 +14,6 @@
 # Use pubsub emulator
 %test.pubsub.use-emulator=true
 %test.quarkus.google.cloud.pubsub.devservice.enabled=true
-%test.quarkus.google.cloud.pubsub.devservice.emulatorPort=8085
 
 # Secret Manager Demo
 # You can load secrets from Google Cloud Secret Manager with the ${sm//<SECRET_ID>} syntax.

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -13,6 +13,8 @@
 
 # Use pubsub emulator
 %test.pubsub.use-emulator=true
+%test.quarkus.google.cloud.pubsub.devservice.enabled=true
+%test.quarkus.google.cloud.pubsub.devservice.emulatorPort=8085
 
 # Secret Manager Demo
 # You can load secrets from Google Cloud Secret Manager with the ${sm//<SECRET_ID>} syntax.

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubResourceTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubResourceTest.java
@@ -4,38 +4,17 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PubSubEmulatorContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
 public class PubSubResourceTest {
-    private static final PubSubEmulatorContainer EMULATOR = new PubSubEmulatorContainer(
-            DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk"));
-
-    @BeforeAll
-    public static void startGcloudContainer() {
-        List<String> portBindings = new ArrayList<>();
-        portBindings.add("8085:8085");
-        EMULATOR.setPortBindings(portBindings);
-        EMULATOR.start();
-    }
-
-    @AfterAll
-    public static void stopGcloudContainer() {
-        EMULATOR.stop();
-    }
 
     @Test
     public void testPubSub() throws ExecutionException, InterruptedException, TimeoutException {

--- a/pubsub/deployment/pom.xml
+++ b/pubsub/deployment/pom.xml
@@ -28,6 +28,10 @@
             <groupId>io.quarkiverse.googlecloudservices</groupId>
             <artifactId>quarkus-google-cloud-pubsub</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>gcloud</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubBuildSteps.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubBuildSteps.java
@@ -4,7 +4,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 
 public class PubSubBuildSteps {
-    private static final String FEATURE = "google-cloud-pubsub";
+    public static final String FEATURE = "google-cloud-pubsub";
 
     @BuildStep
     public FeatureBuildItem feature() {

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubBuildTimeConfig.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubBuildTimeConfig.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.googlecloudservices.pubsub.deployement;
+
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Root configuration class for Google Cloud Pub/Sub that operates at build time.
+ * This class provides a nested structure for configuration, including
+ * a separate group for the development service configuration.
+ */
+@ConfigRoot(name = "google.cloud.pubsub", phase = ConfigPhase.BUILD_TIME)
+public class PubSubBuildTimeConfig {
+
+    /**
+     * Configuration for the Pub/Sub development service.
+     * These settings will be used when Pub/Sub service is being configured
+     * for development purposes.
+     */
+    @ConfigItem
+    public PubSubDevServiceConfig devservice;
+}

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceConfig.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceConfig.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.googlecloudservices.pubsub.deployement;
 
+import java.util.Optional;
+
 import io.quarkus.runtime.annotations.ConfigGroup;
 import io.quarkus.runtime.annotations.ConfigItem;
 
@@ -12,8 +14,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
  *
  * <pre>
  * quarkus.pub-sub-dev-service.enabled = true
- * quarkus.pub-sub-dev-service.image-name = gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators
- * quarkus.pub-sub-dev-service.emulatorPort = 8085
+ * quarkus.pub-sub-dev-service.image-name = gcr.io/google.com/cloudsdktool/google-cloud-cli # optional
+ * quarkus.pub-sub-dev-service.emulatorPort = 8085 # optional
  * </pre>
  */
 @ConfigGroup
@@ -21,23 +23,22 @@ public class PubSubDevServiceConfig {
 
     /**
      * Indicates whether the Pub/Sub service should be enabled or not.
-     * The default value is 'true'.
+     * The default value is 'false'.
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem(defaultValue = "false")
     public boolean enabled;
 
     /**
      * Sets the Docker image name for the Google Cloud SDK.
      * This image is used to emulate the Pub/Sub service in the development environment.
-     * The default value is 'gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators'.
+     * The default value is 'gcr.io/google.com/cloudsdktool/google-cloud-cli'.
      */
-    @ConfigItem(name = "image-name", defaultValue = "gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators")
+    @ConfigItem(name = "image-name", defaultValue = "gcr.io/google.com/cloudsdktool/google-cloud-cli")
     public String imageName;
 
     /**
      * Specifies the emulatorPort on which the Pub/Sub service should run in the development environment.
-     * The default value is '8085'.
      */
-    @ConfigItem(name = "emulatorPort", defaultValue = "8085")
-    public int port;
+    @ConfigItem(name = "emulatorPort")
+    public Optional<Integer> port = Optional.empty();
 }

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceConfig.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceConfig.java
@@ -1,0 +1,43 @@
+package io.quarkiverse.googlecloudservices.pubsub.deployement;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Configuration group for the PubSubDevService. This class holds all the configuration properties
+ * related to the Google Cloud Pub/Sub service for development environments.
+ * <p>
+ * Here is an example of how to configure these properties:
+ * <p>
+ *
+ * <pre>
+ * quarkus.pub-sub-dev-service.enabled = true
+ * quarkus.pub-sub-dev-service.image-name = gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators
+ * quarkus.pub-sub-dev-service.emulatorPort = 8085
+ * </pre>
+ */
+@ConfigGroup
+public class PubSubDevServiceConfig {
+
+    /**
+     * Indicates whether the Pub/Sub service should be enabled or not.
+     * The default value is 'true'.
+     */
+    @ConfigItem(defaultValue = "true")
+    public boolean enabled;
+
+    /**
+     * Sets the Docker image name for the Google Cloud SDK.
+     * This image is used to emulate the Pub/Sub service in the development environment.
+     * The default value is 'gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators'.
+     */
+    @ConfigItem(name = "image-name", defaultValue = "gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators")
+    public String imageName;
+
+    /**
+     * Specifies the emulatorPort on which the Pub/Sub service should run in the development environment.
+     * The default value is '8085'.
+     */
+    @ConfigItem(name = "emulatorPort", defaultValue = "8085")
+    public int port;
+}

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceProcessor.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceProcessor.java
@@ -28,9 +28,9 @@ public class PubSubDevServiceProcessor {
     private static final Logger LOGGER = Logger.getLogger(PubSubDevServiceProcessor.class.getName());
 
     // Running dev service instance
-    static volatile DevServicesResultBuildItem.RunningDevService devService;
+    private static volatile DevServicesResultBuildItem.RunningDevService devService;
     // Configuration for the PubSub Dev service
-    static volatile PubSubDevServiceConfig config;
+    private static volatile PubSubDevServiceConfig config;
 
     @BuildStep
     public DevServicesResultBuildItem startPubSub(DockerStatusBuildItem dockerStatusBuildItem,
@@ -115,10 +115,14 @@ public class PubSubDevServiceProcessor {
         timeout.ifPresent(pubSubEmulatorContainer::withStartupTimeout);
         pubSubEmulatorContainer.start();
 
+        // Set the config for the started container
+        PubSubDevServiceProcessor.config = config;
+
         // Return running service item with container details
         return new DevServicesResultBuildItem.RunningDevService(PubSubBuildSteps.FEATURE,
                 pubSubEmulatorContainer.getContainerId(),
-                pubSubEmulatorContainer::close, "pubsub", pubSubEmulatorContainer.getEmulatorEndpoint());
+                pubSubEmulatorContainer::close, "quarkus.google.cloud.pubsub.emulator-host",
+                pubSubEmulatorContainer.getEmulatorEndpoint());
     }
 
     /**

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceProcessor.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployement/PubSubDevServiceProcessor.java
@@ -1,0 +1,176 @@
+package io.quarkiverse.googlecloudservices.pubsub.deployement;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.jboss.logging.Logger;
+import org.testcontainers.containers.PubSubEmulatorContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.BuildSteps;
+import io.quarkus.deployment.builditem.*;
+import io.quarkus.deployment.console.ConsoleInstalledBuildItem;
+import io.quarkus.deployment.console.StartupLogCompressor;
+import io.quarkus.deployment.dev.devservices.GlobalDevServicesConfig;
+import io.quarkus.deployment.logging.LoggingSetupBuildItem;
+
+/**
+ * Processor responsible for managing PubSub Dev Services.
+ * <p>
+ * The processor starts the PubSub service in case it's not running.
+ */
+@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = GlobalDevServicesConfig.Enabled.class)
+public class PubSubDevServiceProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(PubSubDevServiceProcessor.class.getName());
+
+    // Running dev service instance
+    static volatile DevServicesResultBuildItem.RunningDevService devService;
+    // Configuration for the PubSub Dev service
+    static volatile PubSubDevServiceConfig config;
+
+    @BuildStep
+    public DevServicesResultBuildItem startPubSub(DockerStatusBuildItem dockerStatusBuildItem,
+            PubSubBuildTimeConfig pubSubBuildTimeConfig,
+            List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
+            Optional<ConsoleInstalledBuildItem> consoleInstalledBuildItem,
+            CuratedApplicationShutdownBuildItem closeBuildItem,
+            LaunchModeBuildItem launchMode,
+            LoggingSetupBuildItem loggingSetupBuildItem,
+            GlobalDevServicesConfig globalDevServicesConfig) {
+        // If dev service is running and config has changed, stop the service
+        if (devService != null && !pubSubBuildTimeConfig.devservice.equals(config)) {
+            stopContainer();
+        } else if (devService != null) {
+            return devService.toBuildItem();
+        }
+
+        // Set up log compressor for startup logs
+        StartupLogCompressor compressor = new StartupLogCompressor(
+                (launchMode.isTest() ? "(test) " : "") + "Google Cloud PubSub Dev Services Starting:",
+                consoleInstalledBuildItem,
+                loggingSetupBuildItem);
+
+        // Try starting the container if conditions are met
+        try {
+            devService = startContainerIfAvailable(dockerStatusBuildItem, pubSubBuildTimeConfig.devservice,
+                    globalDevServicesConfig.timeout);
+        } catch (Throwable t) {
+            LOGGER.warn("Unable to start PubSub dev service", t);
+            // Dump captured logs in case of an error
+            compressor.closeAndDumpCaptured();
+            return null;
+        } finally {
+            compressor.close();
+        }
+
+        return devService == null ? null : devService.toBuildItem();
+    }
+
+    /**
+     * Start the container if conditions are met.
+     *
+     * @param dockerStatusBuildItem, Docker status
+     * @param config, Configuration for the PubSub service
+     * @param timeout, Optional timeout for starting the service
+     * @return Running service item, or null if the service couldn't be started
+     */
+    private DevServicesResultBuildItem.RunningDevService startContainerIfAvailable(DockerStatusBuildItem dockerStatusBuildItem,
+            PubSubDevServiceConfig config,
+            Optional<Duration> timeout) {
+        // Start container if PubSub is enabled and Docker is available
+        if (config.enabled && dockerStatusBuildItem.isDockerAvailable()) {
+            return startContainer(dockerStatusBuildItem, config, timeout);
+        } else {
+            LOGGER.warn(
+                    "Not starting Dev Services for PubSub as it has been disabled in the config or Docker is not available");
+            return null;
+        }
+    }
+
+    /**
+     * Starts the PubSub emulator container with provided configuration.
+     *
+     * @param dockerStatusBuildItem, Docker status
+     * @param config, Configuration for the PubSub service
+     * @param timeout, Optional timeout for starting the service
+     * @return Running service item, or null if the service couldn't be started
+     */
+    private DevServicesResultBuildItem.RunningDevService startContainer(DockerStatusBuildItem dockerStatusBuildItem,
+            PubSubDevServiceConfig config,
+            Optional<Duration> timeout) {
+
+        if (!config.enabled) {
+            // PubSub service explicitly disabled
+            LOGGER.debug("Not starting Dev Services for PubSub as it has been disabled in the config");
+            return null;
+        }
+
+        if (!dockerStatusBuildItem.isDockerAvailable()) {
+            LOGGER.warn("Not starting devservice because docker is not available");
+            return null;
+        }
+
+        // Create and configure PubSub emulator container
+        PubSubEmulatorContainer pubSubEmulatorContainer = new QuarkusPubSubContainer(
+                DockerImageName.parse(config.imageName).asCompatibleSubstituteFor("gcr.io/google.com/cloudsdktool/cloud-sdk"),
+                config.port);
+
+        // Set container startup timeout if provided
+        timeout.ifPresent(pubSubEmulatorContainer::withStartupTimeout);
+        pubSubEmulatorContainer.start();
+
+        // Return running service item with container details
+        return new DevServicesResultBuildItem.RunningDevService(PubSubBuildSteps.FEATURE,
+                pubSubEmulatorContainer.getContainerId(),
+                pubSubEmulatorContainer::close, "pubsub", pubSubEmulatorContainer.getEmulatorEndpoint());
+    }
+
+    /**
+     * Stops the running PubSub emulator container.
+     */
+    private void stopContainer() {
+        if (devService != null && devService.isOwner()) {
+            try {
+                // Try closing the running dev service
+                devService.close();
+            } catch (Throwable e) {
+                LOGGER.error("Failed to stop pubsub container", e);
+            } finally {
+                devService = null;
+            }
+        }
+    }
+
+    /**
+     * Class for creating and configuring a PubSub emulator container.
+     */
+    private static class QuarkusPubSubContainer extends PubSubEmulatorContainer {
+
+        private final Integer fixedExposedPort;
+        private static final int PUBSUB_INTERNAL_PORT = 8085;
+
+        private QuarkusPubSubContainer(DockerImageName dockerImageName, Integer fixedExposedPort) {
+            super(dockerImageName);
+            this.fixedExposedPort = fixedExposedPort;
+        }
+
+        /**
+         * Configures the PubSub emulator container.
+         */
+        @Override
+        public void configure() {
+            super.configure();
+
+            // Expose PubSub emulatorPort
+            if (fixedExposedPort != null) {
+                addFixedExposedPort(fixedExposedPort, PUBSUB_INTERNAL_PORT);
+            } else {
+                addExposedPort(PUBSUB_INTERNAL_PORT);
+            }
+        }
+    }
+}

--- a/pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,15 +1,16 @@
 ---
 name: "Google Cloud Pubsub"
+artifact: ${project.groupId}:${project.artifactId}:${project.version}
 metadata:
   keywords:
   - "pubsub"
   - "google cloud"
   - "gcloud"
   - "gcp"
-  guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/pubsub.html"
   categories:
   - "cloud"
   - "messaging"
+  guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/pubsub.html"
   status: "preview"
   config:
   - "quarkus.google.cloud.pubsub."

--- a/pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -12,4 +12,4 @@ metadata:
   - "messaging"
   status: "preview"
   config:
-  - "quarkus.google.cloud.pubsub.*"
+  - "quarkus.google.cloud.pubsub."

--- a/pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/pubsub/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,10 @@ metadata:
   - "google cloud"
   - "gcloud"
   - "gcp"
+  guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-google-cloud-services/main/pubsub.html"
   categories:
-    - "cloud"
-    - "messaging"
+  - "cloud"
+  - "messaging"
   status: "preview"
+  config:
+  - "quarkus.google.cloud.pubsub.*"


### PR DESCRIPTION
Hey there!

Just as I promised, I'm presenting the experimental version of first pubsub devservice, which I already had set up and ready to go. 

This specific devservice is based on the test container implementation of a pubsub emulator, and it's not the only one we can work on using test containers. Here are a few more we can use:

- Bigtable
- Datastore
- Firestore
- Spanner

When it comes to Firebase, though, things may get a little bit more challenging. Unfortunately, test containers don't come with a built-in Firebase implementation, so we'll have to build one from scratch via GenericContainer.

~~This devservice doesn't yet include integration tests.~~

Looking forward to hearing your thoughts on this!