### PR TITLE
Add option to configure GCP logging extension's logging target

### DIFF
--- a/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
+++ b/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
@@ -11,10 +11,12 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
+import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 
 public class LoggingBuildSteps {
 
     private static final String FEATURE = "google-cloud-logging";
+    private static final String QUARKUS_CONSOLE_LOGGING_CONFIG_KEY = "quarkus.log.console.enable";
 
     @BuildStep
     public FeatureBuildItem feature() {
@@ -37,5 +39,16 @@ public class LoggingBuildSteps {
     @Record(ExecutionTime.RUNTIME_INIT)
     public LogHandlerBuildItem handler(LoggingConfiguration config, LoggingHandlerFactory factory) {
         return new LogHandlerBuildItem(factory.create(config));
+    }
+
+    @BuildStep
+    public RunTimeConfigurationDefaultBuildItem configurationDefaultBuildItem(LoggingConfiguration config) {
+        boolean enableConsoleLogging = true;
+        // We should use configuration only if the GCP logging extension is enabled
+        if (config.enabled) {
+            enableConsoleLogging = config.enableConsoleLogging;
+        }
+        return new RunTimeConfigurationDefaultBuildItem(QUARKUS_CONSOLE_LOGGING_CONFIG_KEY,
+                Boolean.toString(enableConsoleLogging));
     }
 }

--- a/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
+++ b/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
@@ -11,12 +11,10 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
-import io.quarkus.deployment.builditem.RunTimeConfigurationDefaultBuildItem;
 
 public class LoggingBuildSteps {
 
     private static final String FEATURE = "google-cloud-logging";
-    private static final String QUARKUS_CONSOLE_LOGGING_CONFIG_KEY = "quarkus.log.console.enable";
 
     @BuildStep
     public FeatureBuildItem feature() {
@@ -39,16 +37,5 @@ public class LoggingBuildSteps {
     @Record(ExecutionTime.RUNTIME_INIT)
     public LogHandlerBuildItem handler(LoggingConfiguration config, LoggingHandlerFactory factory) {
         return new LogHandlerBuildItem(factory.create(config));
-    }
-
-    @BuildStep
-    public RunTimeConfigurationDefaultBuildItem configurationDefaultBuildItem(LoggingConfiguration config) {
-        boolean enableConsoleLogging = true;
-        // We should use configuration only if the GCP logging extension is enabled
-        if (config.enabled) {
-            enableConsoleLogging = config.enableConsoleLogging;
-        }
-        return new RunTimeConfigurationDefaultBuildItem(QUARKUS_CONSOLE_LOGGING_CONFIG_KEY,
-                Boolean.toString(enableConsoleLogging));
     }
 }

--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingConfiguration.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingConfiguration.java
@@ -3,6 +3,7 @@ package io.quarkiverse.googlecloudservices.logging.runtime;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.cloud.logging.LoggingHandler.LogTarget;
 import com.google.cloud.logging.Severity;
 import com.google.cloud.logging.Synchronicity;
 
@@ -11,7 +12,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(name = "google.cloud.logging", phase = ConfigPhase.RUN_TIME)
+@ConfigRoot(name = "google.cloud.logging", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
 public class LoggingConfiguration {
 
     /**
@@ -25,6 +26,12 @@ public class LoggingConfiguration {
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;
+
+    /**
+     * Enable or disable default Quarkus console logging.
+     */
+    @ConfigItem
+    public boolean enableConsoleLogging;
 
     /**
      * Configure base formatting to be either plain text or
@@ -73,6 +80,14 @@ public class LoggingConfiguration {
      */
     @ConfigItem
     public StructuredConfig structured;
+
+    /**
+     * Configures if logs should be written to stdout or stderr instead of using Google Cloud Operations API.
+     * Useful if app is deployed to managed Google Cloud Platform environment with installed logger agent.
+     * Possible values: STDOUT, STDERR and CLOUD_LOGGING.
+     */
+    @ConfigItem(defaultValue = "STDOUT")
+    public LogTarget logTarget;
 
     @ConfigGroup
     public static class StructuredConfig {
@@ -198,4 +213,5 @@ public class LoggingConfiguration {
         TEXT,
         JSON
     }
+
 }

--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingConfiguration.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingConfiguration.java
@@ -86,7 +86,7 @@ public class LoggingConfiguration {
      * Useful if app is deployed to managed Google Cloud Platform environment with installed logger agent.
      * Possible values: STDOUT, STDERR and CLOUD_LOGGING.
      */
-    @ConfigItem(defaultValue = "STDOUT")
+    @ConfigItem(defaultValue = "CLOUD_LOGGING")
     public LogTarget logTarget;
 
     @ConfigGroup

--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingConfiguration.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingConfiguration.java
@@ -12,7 +12,7 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(name = "google.cloud.logging", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(name = "google.cloud.logging", phase = ConfigPhase.RUN_TIME)
 public class LoggingConfiguration {
 
     /**
@@ -26,12 +26,6 @@ public class LoggingConfiguration {
      */
     @ConfigItem(defaultValue = "true")
     public boolean enabled;
-
-    /**
-     * Enable or disable default Quarkus console logging.
-     */
-    @ConfigItem
-    public boolean enableConsoleLogging;
 
     /**
      * Configure base formatting to be either plain text or


### PR DESCRIPTION
This resolves #453.

I introduced two new configuration options:

- `enableConsoleLogging`: with this user can enable or disable default Quarkus console logging. By default, this is disabled so that we prevent duplicated logs.
- `logTarget`: with this user can configure the target of the logs: stdour, stderr, or Google Cloud API. It follows a similar approach as in the official Google Java Logging library (we even use their enums to avoid having to add additional boilerplate code).

With this user has the option to configure logging targets as they wish. They can output logs to Cloud Logging API and still use Quarkus console logging or they disable console logging in case they do not need them or they want to avoid duplication of logs (if they host their app on Google Cloud Platform).

Testing: using Quarkus getting-started sample on local and on GCP environment.