### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/bigtable/runtime/pom.xml
+++ b/bigtable/runtime/pom.xml
@@ -53,8 +53,8 @@
             <artifactId>quarkus-grpc-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
     </dependencies>
 

--- a/common/grpc/pom.xml
+++ b/common/grpc/pom.xml
@@ -55,8 +55,8 @@
             to be able to support 22.2 and 22.3.
         -->
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
         <dependency>
             <groupId>org.graalvm.sdk</groupId>

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -61,8 +61,8 @@
             <artifactId>commons-logging-jboss-logging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145