### PR TITLE
Prevent the usage of OpenTelemetry in GcpDefaultsConfigSourceFactory

### DIFF
--- a/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpDefaultsConfigSourceFactory.java
+++ b/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/GcpDefaultsConfigSourceFactory.java
@@ -16,18 +16,39 @@ import io.smallrye.config.Converters;
 import io.smallrye.config.PropertiesConfigSource;
 
 public class GcpDefaultsConfigSourceFactory implements ConfigSourceFactory {
+
+    private static final String OPENTELEMETRY_CONTEXT_CONTEXT_STORAGE_PROVIDER_SYS_PROP = "io.opentelemetry.context.contextStorageProvider";
+
     @Override
     public Iterable<ConfigSource> getConfigSources(final ConfigSourceContext context) {
         ConfigValue enableMetadataServer = context.getValue("quarkus.google.cloud.enable-metadata-server");
         if (enableMetadataServer.getValue() != null) {
             if (Converters.getImplicitConverter(Boolean.class).convert(enableMetadataServer.getValue())) {
-                String defaultProjectId = ServiceOptions.getDefaultProjectId();
-                if (defaultProjectId != null) {
-                    return singletonList(
-                            new PropertiesConfigSource(Map.of("quarkus.google.cloud.project-id", defaultProjectId),
-                                    "GcpDefaultsConfigSource",
-                                    -Integer.MAX_VALUE));
+                String previousContextStorageSysProp = null;
+                try {
+                    // Google HTTP Client under the hood which attempts to record traces via OpenCensus which is wired
+                    // to delegate to OpenTelemetry.
+                    // This can lead to problems with the Quarkus OpenTelemetry extension which expects Vert.x to be running,
+                    // something that is not the case at build time, see https://github.com/quarkusio/quarkus/issues/35500
+                    previousContextStorageSysProp = System.setProperty(OPENTELEMETRY_CONTEXT_CONTEXT_STORAGE_PROVIDER_SYS_PROP,
+                            "default");
+
+                    String defaultProjectId = ServiceOptions.getDefaultProjectId();
+                    if (defaultProjectId != null) {
+                        return singletonList(
+                                new PropertiesConfigSource(Map.of("quarkus.google.cloud.project-id", defaultProjectId),
+                                        "GcpDefaultsConfigSource",
+                                        -Integer.MAX_VALUE));
+                    }
+                } finally {
+                    if (previousContextStorageSysProp == null) {
+                        System.clearProperty(OPENTELEMETRY_CONTEXT_CONTEXT_STORAGE_PROVIDER_SYS_PROP);
+                    } else {
+                        System.setProperty(OPENTELEMETRY_CONTEXT_CONTEXT_STORAGE_PROVIDER_SYS_PROP,
+                                previousContextStorageSysProp);
+                    }
                 }
+
             }
         }
         return emptyList();


### PR DESCRIPTION
This is needed because GcpDefaultsConfigSourceFactory is called very early in the application startup
and can thus mess up the OpenTelemetry configuration performed later by Quarkus

Fixes: https://github.com/quarkusio/quarkus/issues/35500

P.S. This pattern is also used in Quarkus code [here](https://github.com/quarkusio/quarkus/blob/1eb8b2d80673abe76b9cced7a1cf491872d22748/extensions/container-image/container-image-jib/deployment/src/main/java/io/quarkus/container/image/jib/deployment/JibProcessor.java#L246-L267).