### PR TITLE
feature(bigtable): added bigtable client creation

### DIFF
--- a/bigtable/api/pom.xml
+++ b/bigtable/api/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>quarkus-google-cloud-bigtable-parent</artifactId>
+        <groupId>io.quarkiverse.googlecloudservices</groupId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>quarkus-google-cloud-bigtable-api</artifactId>
+    <name>Quarkus - Google Cloud Services - Bigtable - API</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bigtable/api/pom.xml
+++ b/bigtable/api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>quarkus-google-cloud-bigtable-parent</artifactId>
         <groupId>io.quarkiverse.googlecloudservices</groupId>
-        <version>2.5.0-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/bigtable/api/src/main/java/io/quarkiverse/googlecloudservice/bigtable/api/BigtableClient.java
+++ b/bigtable/api/src/main/java/io/quarkiverse/googlecloudservice/bigtable/api/BigtableClient.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.googlecloudservice.bigtable.api;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+
+/**
+ * Qualifies an injected Bigtable client.
+ */
+@Qualifier
+@Target({ FIELD, PARAMETER })
+@Retention(RUNTIME)
+public @interface BigtableClient {
+
+    /**
+     * Constant value for {@link #value()} indicating that the annotated element's name should be used as-is.
+     */
+    String ELEMENT_NAME = "<<element name>>";
+
+    /**
+     * The name is used to configure the Bigtable client, e.g. the instance, project, etc.
+     *
+     * @return the client name
+     */
+    String value() default ELEMENT_NAME;
+
+    final class Literal extends AnnotationLiteral<BigtableClient> implements BigtableClient {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String value;
+
+        /**
+         * Creates a new instance of {@link Literal}.
+         *
+         * @param value the name of the Bigtable service, must not be {@code null}, must not be {@code blank}
+         * @return the literal instance.
+         */
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        private Literal(String value) {
+            this.value = value;
+        }
+
+        /**
+         * @return the service name.
+         */
+        public String value() {
+            return value;
+        }
+    }
+}

--- a/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigTableDotNames.java
+++ b/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigTableDotNames.java
@@ -4,13 +4,13 @@ import org.jboss.jandex.DotName;
 
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 
+import io.quarkiverse.googlecloudservice.bigtable.api.BigtableClient;
+import io.quarkus.gizmo.MethodDescriptor;
+
 public class BigTableDotNames {
 
-    //public static final DotName BIGTABLE_CLIENT = DotName.createSimple(BigtableClient.class.getName());
+    public static final DotName BIGTABLE_CLIENT = DotName.createSimple(BigtableClient.class.getName());
     public static final DotName DATA_CLIENT = DotName.createSimple(BigtableDataClient.class.getName());
-    /*
-     * public static final MethodDescriptor CREATE_CLIENT_METHOD = MethodDescriptor.ofMethod(BigtableClient.class,
-     * "createClient",
-     * BigtableDataClient.class, String.class);
-     */
+    public static final MethodDescriptor CREATE_CLIENT_METHOD = MethodDescriptor.ofMethod(BigtableClient.class, "createClient",
+            BigtableDataClient.class, String.class);
 }

--- a/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigTableDotNames.java
+++ b/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigTableDotNames.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.googlecloudservices.bigtable.deployment;
+
+import org.jboss.jandex.DotName;
+
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+
+public class BigTableDotNames {
+
+    //public static final DotName BIGTABLE_CLIENT = DotName.createSimple(BigtableClient.class.getName());
+    public static final DotName DATA_CLIENT = DotName.createSimple(BigtableDataClient.class.getName());
+    /*
+     * public static final MethodDescriptor CREATE_CLIENT_METHOD = MethodDescriptor.ofMethod(BigtableClient.class,
+     * "createClient",
+     * BigtableDataClient.class, String.class);
+     */
+}

--- a/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigTableDotNames.java
+++ b/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigTableDotNames.java
@@ -1,16 +1,22 @@
 package io.quarkiverse.googlecloudservices.bigtable.deployment;
 
+import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 
 import io.quarkiverse.googlecloudservice.bigtable.api.BigtableClient;
+import io.quarkiverse.googlecloudservices.bigtable.runtime.BigtableClients;
 import io.quarkus.gizmo.MethodDescriptor;
 
 public class BigTableDotNames {
 
     public static final DotName BIGTABLE_CLIENT = DotName.createSimple(BigtableClient.class.getName());
     public static final DotName DATA_CLIENT = DotName.createSimple(BigtableDataClient.class.getName());
-    public static final MethodDescriptor CREATE_CLIENT_METHOD = MethodDescriptor.ofMethod(BigtableClient.class, "createClient",
+    public static final MethodDescriptor CREATE_CLIENT_METHOD = MethodDescriptor.ofMethod(BigtableClients.class, "createClient",
             BigtableDataClient.class, String.class);
+
+    static boolean isBigtableClient(AnnotationInstance instance) {
+        return instance.name().equals(BIGTABLE_CLIENT);
+    }
 }

--- a/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableBuildItem.java
+++ b/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableBuildItem.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.googlecloudservices.bigtable.deployment;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+public final class BigtableBuildItem extends MultiBuildItem {
+
+    private final String clientName;
+    private final Set<ClientInfo> clients;
+
+    public BigtableBuildItem(String name) {
+        this.clientName = name;
+        this.clients = new HashSet<>();
+    }
+
+    public Set<ClientInfo> getClients() {
+        return clients;
+    }
+
+    public void addClient(ClientInfo client) {
+        clients.add(client);
+        clients.add(new ClientInfo(BigTableDotNames.DATA_CLIENT));
+    }
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public static final class ClientInfo {
+
+        public final DotName className;
+        public final DotName implName;
+
+        public ClientInfo(DotName className) {
+            this(className, null);
+        }
+
+        public ClientInfo(DotName className, DotName implName) {
+            this.className = className;
+            this.implName = implName;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(className);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            ClientInfo other = (ClientInfo) obj;
+            return Objects.equals(className, other.className);
+        }
+
+    }
+}

--- a/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableClientProcessor.java
+++ b/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableClientProcessor.java
@@ -1,6 +1,34 @@
 package io.quarkiverse.googlecloudservices.bigtable.deployment;
 
+import static io.quarkus.deployment.Feature.GRPC_CLIENT;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.inject.Singleton;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationValue;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
 import org.jboss.logging.Logger;
+
+import io.quarkiverse.googlecloudservice.bigtable.api.BigtableClient;
+import io.quarkiverse.googlecloudservices.bigtable.runtime.BigtableConfigProvider;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.arc.deployment.BeanDiscoveryFinishedBuildItem;
+import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
+import io.quarkus.arc.processor.InjectionPointInfo;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.gizmo.MethodCreator;
+import io.quarkus.gizmo.ResultHandle;
 
 public class BigtableClientProcessor {
 
@@ -8,111 +36,98 @@ public class BigtableClientProcessor {
 
     protected static final String FEATURE = "google-cloud-bigtable-client";
 
-    /*
-     * @BuildStep
-     * public void registerBeans(BuildProducer<AdditionalBeanBuildItem> beans) {
-     * beans.produce(new AdditionalBeanBuildItem(BigtableClient.class));
-     * beans.produce(AdditionalBeanBuildItem.builder().setUnremovable().addBeanClasses(BigtableConfigProvider.class).build());
-     * }
-     *
-     * @BuildStep
-     * public void discoverInjectedBeans(BeanDiscoveryFinishedBuildItem beanDiscovery,
-     * BuildProducer<BigtableBuildItem> clients,
-     * BuildProducer<FeatureBuildItem> features,
-     * CombinedIndexBuildItem index) {
-     *
-     * Map<String, BigtableBuildItem> items = new HashMap<>();
-     *
-     * for (InjectionPointInfo injectionPoint : beanDiscovery.getInjectionPoints()) {
-     * AnnotationInstance clientAnnotation = injectionPoint.getRequiredQualifier(BigTableDotNames.BIGTABLE_CLIENT);
-     * if (clientAnnotation == null) {
-     * continue;
-     * }
-     *
-     * String clientName;
-     * AnnotationValue clientNameValue = clientAnnotation.value();
-     * if (clientNameValue == null || clientNameValue.asString().equals(BigtableClient.ELEMENT_NAME)) {
-     * // Determine the service name from the annotated element
-     * if (clientAnnotation.target().kind() == AnnotationTarget.Kind.FIELD) {
-     * clientName = clientAnnotation.target().asField().name();
-     * } else if (clientAnnotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
-     * MethodParameterInfo param = clientAnnotation.target().asMethodParameter();
-     * clientName = param.method().parameterName(param.position());
-     * if (clientName == null) {
-     * throw new DeploymentException("Unable to determine the client name from the parameter at position "
-     * + param.position()
-     * + " in method "
-     * + param.method().declaringClass().name() + "#" + param.method().name()
-     * +
-     * "() - compile the class with debug info enabled (-g) or parameter names recorded (-parameters), or use GrpcClient#value() to specify the service name"
-     * );
-     * }
-     * } else {
-     * // This should never happen because @BigtableClient has @Target({ FIELD, PARAMETER })
-     * throw new IllegalStateException(clientAnnotation + " may not be declared at " + clientAnnotation.target());
-     * }
-     * } else {
-     * clientName = clientNameValue.asString();
-     * }
-     *
-     * if (clientName.trim().isEmpty()) {
-     * throw new DeploymentException(
-     * "Invalid @BigtableClient `" + injectionPoint.getTargetInfo() + "` - client name cannot be empty");
-     * }
-     *
-     * BigtableBuildItem item;
-     * if (items.containsKey(clientName)) {
-     * item = items.get(clientName);
-     * } else {
-     * item = new BigtableBuildItem(clientName);
-     * items.put(clientName, item);
-     * }
-     *
-     * Type injectionType = injectionPoint.getRequiredType();
-     * if (injectionType.name().equals(BigTableDotNames.DATA_CLIENT)) {
-     * item.addClient(new BigtableBuildItem.ClientInfo(BigTableDotNames.DATA_CLIENT));
-     * }
-     * }
-     *
-     * if (!items.isEmpty()) {
-     * for (BigtableBuildItem item : items.values()) {
-     * clients.produce(item);
-     * LOGGER.debugf("Detected client associated with the '%s' configuration prefix", item.getClientName());
-     * }
-     * features.produce(new FeatureBuildItem(GRPC_CLIENT));
-     * }
-     * }
-     *
-     * @BuildStep
-     * public void generateGrpcClientProducers(List<BigtableBuildItem> clients,
-     * BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
-     *
-     * for (BigtableBuildItem client : clients) {
-     * for (BigtableBuildItem.ClientInfo clientInfo : client.getClients()) {
-     * SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
-     * .configure(BigTableDotNames.DATA_CLIENT)
-     * .addQualifier().annotation(BigTableDotNames.BIGTABLE_CLIENT).addValue("value", client.getClientName())
-     * .done()
-     * .scope(Singleton.class)
-     * .unremovable()
-     * .forceApplicationClass()
-     * .creator(new Consumer<>() {
-     *
-     * @Override
-     * public void accept(MethodCreator mc) {
-     * BigtableClientProcessor.this.generateChannelProducer(mc, client.getClientName());
-     * }
-     * });
-     * syntheticBeans.produce(configurator.done());
-     * }
-     * }
-     * }
-     *
-     * private void generateChannelProducer(MethodCreator mc, String clientName) {
-     * ResultHandle name = mc.load(clientName);
-     * ResultHandle result = mc.invokeStaticMethod(BigTableDotNames.CREATE_CLIENT_METHOD, name);
-     * mc.returnValue(result);
-     * mc.close();
-     * }
-     */
+    @BuildStep
+    public void registerBeans(BuildProducer<AdditionalBeanBuildItem> beans) {
+        beans.produce(new AdditionalBeanBuildItem(BigtableClient.class));
+        beans.produce(AdditionalBeanBuildItem.builder().setUnremovable().addBeanClasses(BigtableConfigProvider.class).build());
+    }
+
+    @BuildStep
+    public void discoverInjectedBeans(BeanDiscoveryFinishedBuildItem beanDiscovery,
+            BuildProducer<BigtableBuildItem> clients,
+            BuildProducer<FeatureBuildItem> features,
+            CombinedIndexBuildItem index) {
+        Map<String, BigtableBuildItem> items = new HashMap<>();
+        for (InjectionPointInfo injectionPoint : beanDiscovery.getInjectionPoints()) {
+            AnnotationInstance clientAnnotation = injectionPoint.getRequiredQualifier(BigTableDotNames.BIGTABLE_CLIENT);
+            if (clientAnnotation == null) {
+                continue;
+            }
+            String clientName;
+            AnnotationValue clientNameValue = clientAnnotation.value();
+            if (clientNameValue == null || clientNameValue.asString().equals(BigtableClient.ELEMENT_NAME)) {
+                // Determine the service name from the annotated element
+                if (clientAnnotation.target().kind() == AnnotationTarget.Kind.FIELD) {
+                    clientName = clientAnnotation.target().asField().name();
+                } else if (clientAnnotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
+                    MethodParameterInfo param = clientAnnotation.target().asMethodParameter();
+                    clientName = param.method().parameterName(param.position());
+                    if (clientName == null) {
+                        throw new DeploymentException("Unable to determine the client name from the parameter at position "
+                                + param.position()
+                                + " in method "
+                                + param.method().declaringClass().name() + "#" + param.method().name()
+                                +
+                                "() - compile the class with debug info enabled (-g) or parameter names recorded (-parameters), or use GrpcClient#value() to specify the service name");
+                    }
+                } else {
+                    // This should never happen because @BigtableClient has @Target({ FIELD, PARAMETER })
+                    throw new IllegalStateException(clientAnnotation + " may not be declared at " + clientAnnotation.target());
+                }
+            } else {
+                clientName = clientNameValue.asString();
+            }
+            if (clientName.trim().isEmpty()) {
+                throw new DeploymentException(
+                        "Invalid @BigtableClient `" + injectionPoint.getTargetInfo() + "` - client name cannot be empty");
+            }
+            BigtableBuildItem item;
+            if (items.containsKey(clientName)) {
+                item = items.get(clientName);
+            } else {
+                item = new BigtableBuildItem(clientName);
+                items.put(clientName, item);
+            }
+            Type injectionType = injectionPoint.getRequiredType();
+            if (injectionType.name().equals(BigTableDotNames.DATA_CLIENT)) {
+                item.addClient(new BigtableBuildItem.ClientInfo(BigTableDotNames.DATA_CLIENT));
+            }
+        }
+        if (!items.isEmpty()) {
+            for (BigtableBuildItem item : items.values()) {
+                clients.produce(item);
+                LOGGER.debugf("Detected client associated with the '%s' configuration prefix", item.getClientName());
+            }
+            features.produce(new FeatureBuildItem(GRPC_CLIENT));
+        }
+    }
+
+    @BuildStep
+    public void generateGrpcClientProducers(List<BigtableBuildItem> clients,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+        for (BigtableBuildItem client : clients) {
+            for (BigtableBuildItem.ClientInfo clientInfo : client.getClients()) {
+                SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem.configure(clientInfo.className)
+                        .addQualifier().annotation(BigTableDotNames.BIGTABLE_CLIENT).addValue("value", client.getClientName()).done()
+                        .scope(Singleton.class)
+                        .unremovable()
+                        .forceApplicationClass()
+                        .creator(new Consumer<MethodCreator>() {
+                            @Override
+                            public void accept(MethodCreator mc) {
+                                BigtableClientProcessor.this.generateClientProducer(mc, client.getClientName());
+                            }
+                        });
+                syntheticBeans.produce(configurator.done());
+            }
+        }
+    }
+
+    private void generateClientProducer(MethodCreator mc, String clientName) {
+        ResultHandle name = mc.load(clientName);
+        ResultHandle result = mc.invokeStaticMethod(BigTableDotNames.CREATE_CLIENT_METHOD, name);
+        mc.returnValue(result);
+        mc.close();
+    }
+
 }

--- a/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableClientProcessor.java
+++ b/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableClientProcessor.java
@@ -1,7 +1,5 @@
 package io.quarkiverse.googlecloudservices.bigtable.deployment;
 
-import static io.quarkus.deployment.Feature.GRPC_CLIENT;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +37,7 @@ public class BigtableClientProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(BigtableClientProcessor.class.getName());
 
-    protected static final String FEATURE = "google-cloud-bigtable-client";
+    private static final String FEATURE = "google-cloud-bigtable-client";
 
     @BuildStep
     public void registerBeans(BuildProducer<AdditionalBeanBuildItem> beans) {
@@ -73,7 +71,7 @@ public class BigtableClientProcessor {
                                 + " in method "
                                 + param.method().declaringClass().name() + "#" + param.method().name()
                                 +
-                                "() - compile the class with debug info enabled (-g) or parameter names recorded (-parameters), or use GrpcClient#value() to specify the service name");
+                                "() - compile the class with debug info enabled (-g) or parameter names recorded (-parameters), or use BigtableClient#value() to specify the service name");
                     }
                 } else {
                     // This should never happen because @BigtableClient has @Target({ FIELD, PARAMETER })
@@ -103,12 +101,12 @@ public class BigtableClientProcessor {
                 clients.produce(item);
                 LOGGER.debugf("Detected client associated with the '%s' configuration prefix", item.getClientName());
             }
-            features.produce(new FeatureBuildItem(GRPC_CLIENT));
+            features.produce(new FeatureBuildItem(FEATURE));
         }
     }
 
     @BuildStep
-    public void generateGrpcClientProducers(List<BigtableBuildItem> clients,
+    public void generateBigtableClientProducers(List<BigtableBuildItem> clients,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
         for (BigtableBuildItem client : clients) {
             for (BigtableBuildItem.ClientInfo clientInfo : client.getClients()) {

--- a/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableClientProcessor.java
+++ b/bigtable/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigtable/deployment/BigtableClientProcessor.java
@@ -1,0 +1,118 @@
+package io.quarkiverse.googlecloudservices.bigtable.deployment;
+
+import org.jboss.logging.Logger;
+
+public class BigtableClientProcessor {
+
+    private static final Logger LOGGER = Logger.getLogger(BigtableClientProcessor.class.getName());
+
+    protected static final String FEATURE = "google-cloud-bigtable-client";
+
+    /*
+     * @BuildStep
+     * public void registerBeans(BuildProducer<AdditionalBeanBuildItem> beans) {
+     * beans.produce(new AdditionalBeanBuildItem(BigtableClient.class));
+     * beans.produce(AdditionalBeanBuildItem.builder().setUnremovable().addBeanClasses(BigtableConfigProvider.class).build());
+     * }
+     *
+     * @BuildStep
+     * public void discoverInjectedBeans(BeanDiscoveryFinishedBuildItem beanDiscovery,
+     * BuildProducer<BigtableBuildItem> clients,
+     * BuildProducer<FeatureBuildItem> features,
+     * CombinedIndexBuildItem index) {
+     *
+     * Map<String, BigtableBuildItem> items = new HashMap<>();
+     *
+     * for (InjectionPointInfo injectionPoint : beanDiscovery.getInjectionPoints()) {
+     * AnnotationInstance clientAnnotation = injectionPoint.getRequiredQualifier(BigTableDotNames.BIGTABLE_CLIENT);
+     * if (clientAnnotation == null) {
+     * continue;
+     * }
+     *
+     * String clientName;
+     * AnnotationValue clientNameValue = clientAnnotation.value();
+     * if (clientNameValue == null || clientNameValue.asString().equals(BigtableClient.ELEMENT_NAME)) {
+     * // Determine the service name from the annotated element
+     * if (clientAnnotation.target().kind() == AnnotationTarget.Kind.FIELD) {
+     * clientName = clientAnnotation.target().asField().name();
+     * } else if (clientAnnotation.target().kind() == AnnotationTarget.Kind.METHOD_PARAMETER) {
+     * MethodParameterInfo param = clientAnnotation.target().asMethodParameter();
+     * clientName = param.method().parameterName(param.position());
+     * if (clientName == null) {
+     * throw new DeploymentException("Unable to determine the client name from the parameter at position "
+     * + param.position()
+     * + " in method "
+     * + param.method().declaringClass().name() + "#" + param.method().name()
+     * +
+     * "() - compile the class with debug info enabled (-g) or parameter names recorded (-parameters), or use GrpcClient#value() to specify the service name"
+     * );
+     * }
+     * } else {
+     * // This should never happen because @BigtableClient has @Target({ FIELD, PARAMETER })
+     * throw new IllegalStateException(clientAnnotation + " may not be declared at " + clientAnnotation.target());
+     * }
+     * } else {
+     * clientName = clientNameValue.asString();
+     * }
+     *
+     * if (clientName.trim().isEmpty()) {
+     * throw new DeploymentException(
+     * "Invalid @BigtableClient `" + injectionPoint.getTargetInfo() + "` - client name cannot be empty");
+     * }
+     *
+     * BigtableBuildItem item;
+     * if (items.containsKey(clientName)) {
+     * item = items.get(clientName);
+     * } else {
+     * item = new BigtableBuildItem(clientName);
+     * items.put(clientName, item);
+     * }
+     *
+     * Type injectionType = injectionPoint.getRequiredType();
+     * if (injectionType.name().equals(BigTableDotNames.DATA_CLIENT)) {
+     * item.addClient(new BigtableBuildItem.ClientInfo(BigTableDotNames.DATA_CLIENT));
+     * }
+     * }
+     *
+     * if (!items.isEmpty()) {
+     * for (BigtableBuildItem item : items.values()) {
+     * clients.produce(item);
+     * LOGGER.debugf("Detected client associated with the '%s' configuration prefix", item.getClientName());
+     * }
+     * features.produce(new FeatureBuildItem(GRPC_CLIENT));
+     * }
+     * }
+     *
+     * @BuildStep
+     * public void generateGrpcClientProducers(List<BigtableBuildItem> clients,
+     * BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+     *
+     * for (BigtableBuildItem client : clients) {
+     * for (BigtableBuildItem.ClientInfo clientInfo : client.getClients()) {
+     * SyntheticBeanBuildItem.ExtendedBeanConfigurator configurator = SyntheticBeanBuildItem
+     * .configure(BigTableDotNames.DATA_CLIENT)
+     * .addQualifier().annotation(BigTableDotNames.BIGTABLE_CLIENT).addValue("value", client.getClientName())
+     * .done()
+     * .scope(Singleton.class)
+     * .unremovable()
+     * .forceApplicationClass()
+     * .creator(new Consumer<>() {
+     *
+     * @Override
+     * public void accept(MethodCreator mc) {
+     * BigtableClientProcessor.this.generateChannelProducer(mc, client.getClientName());
+     * }
+     * });
+     * syntheticBeans.produce(configurator.done());
+     * }
+     * }
+     * }
+     *
+     * private void generateChannelProducer(MethodCreator mc, String clientName) {
+     * ResultHandle name = mc.load(clientName);
+     * ResultHandle result = mc.invokeStaticMethod(BigTableDotNames.CREATE_CLIENT_METHOD, name);
+     * mc.returnValue(result);
+     * mc.close();
+     * }
+     */
+}

--- a/bigtable/pom.xml
+++ b/bigtable/pom.xml
@@ -13,6 +13,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>api</module>
         <module>runtime</module>
         <module>deployment</module>
     </modules>

--- a/bigtable/runtime/pom.xml
+++ b/bigtable/runtime/pom.xml
@@ -14,6 +14,11 @@
     <dependencies>
         <dependency>
             <groupId>io.quarkiverse.googlecloudservices</groupId>
+            <artifactId>quarkus-google-cloud-bigtable-api</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.googlecloudservices</groupId>
             <artifactId>quarkus-google-cloud-common</artifactId>
         </dependency>
         <dependency>

--- a/bigtable/runtime/pom.xml
+++ b/bigtable/runtime/pom.xml
@@ -15,7 +15,6 @@
         <dependency>
             <groupId>io.quarkiverse.googlecloudservices</groupId>
             <artifactId>quarkus-google-cloud-bigtable-api</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.googlecloudservices</groupId>

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigTableClientConfiguration.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigTableClientConfiguration.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.googlecloudservices.bigtable.runtime;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+/**
+ * Configuration for the Bigtable clients.
+ * These settings will be used when Bigtable clients are being configured.
+ */
+@ConfigGroup
+public class BigTableClientConfiguration {
+
+    /**
+     * The project id.
+     */
+    @ConfigItem
+    public String instanceId;
+}

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableClients.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableClients.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.googlecloudservices.bigtable.runtime;
+
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+import io.quarkus.runtime.LaunchMode;
+
+public class BigtableClients {
+
+    public static BigtableDataClient createClient(String name) throws Exception {
+        ArcContainer container = Arc.container();
+
+        InstanceHandle<BigtableConfigProvider> configProvider = container.instance(BigtableConfigProvider.class);
+        if (!configProvider.isAvailable()) {
+            throw new Exception("BigtableConfigProvider not available");
+        }
+
+        BigtableConfigProvider provider = configProvider.get();
+        BigTableClientConfiguration config = provider.getConfiguration(name);
+        String projectId = provider.getProjectId();
+
+        if (config == null && LaunchMode.current() == LaunchMode.TEST) {
+            return null;
+        }
+
+        if (config == null || projectId == null) {
+            throw new IllegalStateException("Bigtable configuration not found");
+        }
+
+        BigtableDataSettings.Builder settings = BigtableDataSettings.newBuilder()
+                .setProjectId(projectId)
+                .setInstanceId(config.instanceId);
+
+        return BigtableDataClient.create(settings.build());
+    }
+}

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfigProvider.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfigProvider.java
@@ -1,0 +1,29 @@
+package io.quarkiverse.googlecloudservices.bigtable.runtime;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+public class BigtableConfigProvider {
+
+    @Inject
+    BigtableConfiguration config;
+
+    @ConfigProperty(name = "quarkus.google.cloud.project-id")
+    String projectId;
+
+    public BigTableClientConfiguration getConfiguration(String name) {
+        Map<String, BigTableClientConfiguration> clients = config.clients;
+        if (clients == null) {
+            return null;
+        } else {
+            return clients.get(name);
+        }
+    }
+
+    public String getProjectId() {
+        return projectId;
+    }
+}

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfigProvider.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfigProvider.java
@@ -14,6 +14,9 @@ public class BigtableConfigProvider {
     @ConfigProperty(name = "quarkus.google.cloud.project-id")
     String projectId;
 
+    @ConfigProperty(name = "quarkus.google.cloud.bigtable.emulator-host")
+    String emulatorHost;
+
     public BigTableClientConfiguration getConfiguration(String name) {
         Map<String, BigTableClientConfiguration> clients = config.clients;
         if (clients == null) {
@@ -25,5 +28,9 @@ public class BigtableConfigProvider {
 
     public String getProjectId() {
         return projectId;
+    }
+
+    public String getEmulatorHost() {
+        return emulatorHost;
     }
 }

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfiguration.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfiguration.java
@@ -2,8 +2,6 @@ package io.quarkiverse.googlecloudservices.bigtable.runtime;
 
 import java.util.Map;
 
-import io.quarkus.runtime.annotations.ConfigDocMapKey;
-import io.quarkus.runtime.annotations.ConfigDocSection;
 import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
@@ -21,7 +19,5 @@ public class BigtableConfiguration {
      * These settings will be used when Bigtable clients are being configured.
      */
     @ConfigItem
-    @ConfigDocSection
-    @ConfigDocMapKey("client-name")
     public Map<String, BigTableClientConfiguration> clients;
 }

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfiguration.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableConfiguration.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.googlecloudservices.bigtable.runtime;
+
+import java.util.Map;
+
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+
+/**
+ * Root configuration class for Bigtable that operates at runtime.
+ * This class provides a nested structure for configuration, including
+ * a separate group for the client configuration.
+ */
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class BigtableConfiguration {
+
+    /**
+     * Configuration for the Bigtable clients.
+     * These settings will be used when Bigtable clients are being configured.
+     */
+    @ConfigItem
+    @ConfigDocSection
+    @ConfigDocMapKey("client-name")
+    public Map<String, BigTableClientConfiguration> clients;
+}

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableCredentialsProvider.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableCredentialsProvider.java
@@ -1,0 +1,4 @@
+package io.quarkiverse.googlecloudservices.bigtable.runtime;
+
+public class BigtableCredentialsProvider {
+}

--- a/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableCredentialsProvider.java
+++ b/bigtable/runtime/src/main/java/io/quarkiverse/googlecloudservices/bigtable/runtime/BigtableCredentialsProvider.java
@@ -1,4 +1,20 @@
 package io.quarkiverse.googlecloudservices.bigtable.runtime;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+
+@ApplicationScoped
 public class BigtableCredentialsProvider {
+
+    @Inject
+    CredentialsProvider credentialsProvider;
+
+    public void applyCredentials(BigtableDataSettings.Builder builder) {
+        if (credentialsProvider != null) {
+            builder.setCredentialsProvider(credentialsProvider);
+        }
+    }
 }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -119,6 +119,11 @@
             </dependency>
             <dependency>
                 <groupId>io.quarkiverse.googlecloudservices</groupId>
+                <artifactId>quarkus-google-cloud-bigtable-api</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.quarkiverse.googlecloudservices</groupId>
                 <artifactId>quarkus-google-cloud-bigtable</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/BigtableResource.java
+++ b/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/BigtableResource.java
@@ -1,14 +1,5 @@
 package io.quarkiverse.googlecloudservices.it;
 
-import java.io.IOException;
-
-import jakarta.annotation.PostConstruct;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
@@ -24,9 +15,16 @@ import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
-
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.quarkiverse.googlecloudservice.bigtable.api.BigtableClient;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import java.io.IOException;
 
 @Path("/bigtable")
 public class BigtableResource {
@@ -42,6 +40,10 @@ public class BigtableResource {
 
     @ConfigProperty(name = "quarkus.google.cloud.bigtable.emulator-host")
     String emulatorHost;
+
+    @Inject
+    @BigtableClient
+    BigtableDataClient dataClient;
 
     @Inject
     CredentialsProvider credentialsProvider;

--- a/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/BigtableResource.java
+++ b/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/BigtableResource.java
@@ -1,5 +1,14 @@
 package io.quarkiverse.googlecloudservices.it;
 
+import java.io.IOException;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
@@ -15,16 +24,10 @@ import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.quarkiverse.googlecloudservice.bigtable.api.BigtableClient;
-import jakarta.annotation.PostConstruct;
-import jakarta.inject.Inject;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import java.io.IOException;
 
 @Path("/bigtable")
 public class BigtableResource {
@@ -109,9 +112,9 @@ public class BigtableResource {
         try (BigtableDataClient dataClient = BigtableDataClient.create(settings.build())) {
             // create a row
             RowMutation rowMutation = RowMutation.create(TABLE_ID, "key1").setCell(COLUMN_FAMILY_ID, "test", "value1");
-            dataClient.mutateRow(rowMutation);
+            this.dataClient.mutateRow(rowMutation);
 
-            Row row = dataClient.readRow(TABLE_ID, "key1");
+            Row row = this.dataClient.readRow(TABLE_ID, "key1");
             StringBuilder cells = new StringBuilder();
             for (RowCell cell : row.getCells()) {
                 cells.append(String.format(


### PR DESCRIPTION
This PR introduces an experimental version of the Bigtable client creation. 

**Summary:**

- Introduced a BigtableClient annotation that qualifies an injected Bigtable client.
- The BigtableClientProcessor class is responsible for registering beans, discovering injected beans, generating bigtable client producers, and transforming injection points. This ensures the right Bigtable client is used based on the configuration and qualifiers.
- The main class BigtableClients handles the creation of the Bigtable client.
- The system for bean creation is based on grpc client bean creation.

Also configuration will be made so that you can configure it like this:

```
quarkus.google.cloud.bigtable.clients.test-client.instance-id=test-instance
```

or default client:

```
quarkus.google.cloud.bigtable.clients.instance-id=test-instance
```

The introduced Bigtable client creation is experimental and may be subject to changes based on further testing.