### PR TITLE
EmulatorCredentials when running on dev services

### DIFF
--- a/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
+++ b/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/FirestoreProducer.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -23,7 +24,7 @@ import io.quarkiverse.googlecloudservices.firestore.runtime.FirestoreConfigurati
 public class FirestoreProducer {
 
     @Inject
-    Credentials googleCredentials;
+    Instance<Credentials> googleCredentials;
 
     @Inject
     GcpConfigHolder gcpConfigHolder;
@@ -31,17 +32,25 @@ public class FirestoreProducer {
     @Inject
     FirestoreConfiguration firestoreConfiguration;
 
+    @Inject
+    GcpBootstrapConfiguration gcpBootstrapConfiguration;
+
     @Produces
     @Singleton
     @Default
     public Firestore firestore() throws IOException {
         GcpBootstrapConfiguration gcpConfiguration = gcpConfigHolder.getBootstrapConfig();
         FirestoreOptions.Builder builder = FirestoreOptions.newBuilder()
-                .setCredentials(googleCredentials)
                 .setProjectId(gcpConfiguration.projectId().orElse(null));
-        firestoreConfiguration.hostOverride.ifPresent(builder::setHost);
-        firestoreConfiguration.retry.ifPresent(retry -> builder.setRetrySettings(buildRetrySettings(retry)));
-        firestoreConfiguration.databaseId.ifPresent(databaseId -> builder.setDatabaseId(databaseId));
+        if (useEmulatorCredentials()) {
+            builder.setCredentials(new FirestoreOptions.EmulatorCredentials());
+            firestoreConfiguration.hostOverride.ifPresent(builder::setEmulatorHost);
+        } else {
+            builder.setCredentials(googleCredentials.get());
+            firestoreConfiguration.hostOverride.ifPresent(builder::setHost);
+            firestoreConfiguration.retry.map(this::buildRetrySettings).ifPresent(builder::setRetrySettings);
+            firestoreConfiguration.databaseId.ifPresent(builder::setDatabaseId);
+        }
         return builder.build().getService();
     }
 
@@ -66,6 +75,18 @@ public class FirestoreProducer {
      */
     private Duration convertDuration(java.time.Duration duration) {
         return Duration.ofMillis(duration.toMillis());
+    }
+
+    /**
+     * Determine if we need to use emulator credentials. Emulator credentials are used in case the host-override is set
+     * and we don't have accessTokens enabled.
+     *
+     * @return whether to use the emulator credentials
+     */
+    private boolean useEmulatorCredentials() {
+        return !this.gcpBootstrapConfiguration.accessTokenEnabled()
+                && this.firestoreConfiguration.hostOverride.isPresent()
+                && this.firestoreConfiguration.hostOverride.get().contains("localhost");
     }
 
 }

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -4,6 +4,7 @@
 
 # We use a dummy test project id in test for the emulators to work
 %test.quarkus.google.cloud.project-id=test-project
+%test.quarkus.google.cloud.access-token-enabled=false
 %test.quarkus.google.cloud.storage.host-override=http://localhost:8089
 %test.quarkus.google.cloud.spanner.emulator-host=http://localhost:9010
 

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/FirestoreResourceTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/FirestoreResourceTest.java
@@ -10,9 +10,17 @@ import io.quarkus.test.junit.QuarkusTest;
 public class FirestoreResourceTest {
 
     @Test
-    public void testFirestore() {
+    public void testFirestoreQuery() {
         given()
-                .when().get("/firestore")
+                .when().get("/firestore/query")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void testFirestoreListDocuments() {
+        given()
+                .when().get("/firestore/all")
                 .then()
                 .statusCode(200);
     }


### PR DESCRIPTION
Implementation to use EmulatorCredentials for dev services (unless access-token-enabled = true)