### PR TITLE
Upgrade com.google.cloud:libraries-bom to 26.45.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <google-cloud-sdk.version>26.43.0</google-cloud-sdk.version>
+        <google-cloud-sdk.version>26.45.0</google-cloud-sdk.version>
 
         <!-- Dependency convergence issues -->
         <opencensus.version>0.31.1</opencensus.version><!-- mess in google-pubsub and grpc deps; should be rather stable as OpenCensus has been sunsetted already - see https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/862 -->

--- a/common/grpc/src/main/java/io/quarkiverse/googlecloudservices/common/grpc/runtime/graal/GoogleApiGaxGrpcSubstitutions.java
+++ b/common/grpc/src/main/java/io/quarkiverse/googlecloudservices/common/grpc/runtime/graal/GoogleApiGaxGrpcSubstitutions.java
@@ -1,10 +1,9 @@
 package io.quarkiverse.googlecloudservices.common.grpc.runtime.graal;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-
-import org.threeten.bp.Duration;
 
 import com.google.api.core.ApiFunction;
 import com.google.api.gax.grpc.ChannelPrimer;


### PR DESCRIPTION
Replaces https://github.com/quarkiverse/quarkus-google-cloud-services/pull/659.

@loicmathieu 26.45.0 is the version of `libraries-bom` that Camel will be aligned with in the upcoming Quarkus 3.15.0 release.

If possible, It'd be good to get a new release of `quarkus-google-cloud-services` so that we are in alignment with the Google Cloud bits in the Quarkus Platform.