### PR TITLE
Issue 674 gcp logging spaninfo

### DIFF
--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandler.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandler.java
@@ -2,7 +2,6 @@ package io.quarkiverse.googlecloudservices.logging.runtime;
 
 import java.util.Collections;
 import java.util.logging.ErrorManager;
-import java.util.logging.Level;
 
 import org.jboss.logmanager.ExtHandler;
 import org.jboss.logmanager.ExtLogRecord;
@@ -12,7 +11,6 @@ import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.Logging;
 import com.google.cloud.logging.Logging.WriteOption;
 import com.google.cloud.logging.Payload;
-import com.google.cloud.logging.Severity;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
@@ -26,10 +24,6 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
 
 public class LoggingHandler extends ExtHandler {
-
-    private static final String LEVEL_NAME_KEY = "levelName";
-    private static final String LEVEL_VALUE_KEY = "levelValue";
-    private static final String LOGGER_NAME_KEY = "loggerName";
 
     private final LoggingConfiguration config;
 
@@ -85,18 +79,9 @@ public class LoggingHandler extends ExtHandler {
     private LogEntry transform(ExtLogRecord record, TraceInfo trace) {
         Payload<?> payload = internalHandler.transform(record, trace);
         if (payload != null) {
-            Level level = record.getLevel();
-            Severity severity = LevelTransformer.toSeverity(level);
             com.google.cloud.logging.LogEntry.Builder builder = LogEntry.newBuilder(payload)
-                    .setSeverity(severity)
-                    .setTimestamp(record.getInstant())
-                    .addLabel(LEVEL_NAME_KEY, level.toString())
-                    .addLabel(LEVEL_VALUE_KEY, String.valueOf(level.intValue()));
-
-            String loggerName = record.getSourceClassName();
-            if (!Strings.isNullOrEmpty(loggerName)) {
-                builder = builder.addLabel(LOGGER_NAME_KEY, loggerName);
-            }
+                    .setSeverity(LevelTransformer.toSeverity(record.getLevel()))
+                    .setTimestamp(record.getInstant());
 
             if (this.config.gcpTracing().enabled() && trace != null && !Strings.isNullOrEmpty(trace.getTraceId())) {
                 builder = builder
@@ -119,7 +104,7 @@ public class LoggingHandler extends ExtHandler {
         try {
             initGetLogging().flush();
         } catch (Exception ex) {
-            getErrorManager().error("Failed to fluch GCP logger", ex, ErrorManager.FLUSH_FAILURE);
+            getErrorManager().error("Failed to flush GCP logger", ex, ErrorManager.FLUSH_FAILURE);
         }
     }
 

--- a/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
+++ b/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
@@ -1,0 +1,158 @@
+package io.quarkiverse.googlecloudservices.logging.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Level;
+
+import org.jboss.logmanager.ExtLogRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import com.google.cloud.logging.Logging;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.quarkus.arc.Arc;
+import io.quarkus.arc.ArcContainer;
+import io.quarkus.arc.InstanceHandle;
+
+/**
+ * Unit tests for the {@link LoggingHandler} class.
+ */
+class LoggingHandlerTest {
+
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+
+    @BeforeEach
+    void setUp() {
+        // This enables us to capture anything written via System.out.println during a test
+        System.setOut(new PrintStream(outputStreamCaptor));
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Reset System.out after test complete
+        System.setOut(System.out);
+    }
+
+    @Test
+    void shouldLogToStdoutWithTraceInfoAndLabels() {
+        String traceId = UUID.randomUUID().toString();
+        String spanId = UUID.randomUUID().toString();
+        String msg = "hello world";
+        String projectId = "my-project";
+        int sourceLineNumber = 101;
+
+        ArcContainer container = createArcContainer(traceId, spanId);
+
+        try (MockedStatic<Arc> arc = Mockito.mockStatic(Arc.class)) {
+            arc.when(Arc::container).thenReturn(container);
+
+            try (LoggingHandler h = new LoggingHandler(createJsonStdoutLoggingConfiguration(projectId))) {
+                // Publish a log record
+                h.doPublish(createNewInfoLogRecord(msg, sourceLineNumber));
+            }
+
+            // Assert on what was written to System.out
+            final String logEntry = outputStreamCaptor.toString();
+            assertNotNull(logEntry);
+            JsonObject logEntryJson = JsonParser.parseString(logEntry).getAsJsonObject();
+            assertAll(
+                    () -> assertEquals("INFO", logEntryJson.get("severity").getAsString()),
+                    () -> assertNotNull(logEntryJson.get("time").getAsString()),
+                    () -> assertNotNull(logEntryJson.get("@timestamp").getAsString()),
+                    () -> assertEquals(msg, logEntryJson.get("message").getAsString()),
+                    () -> assertEquals(String.format("projects/%s/traces/%s", projectId, traceId),
+                            logEntryJson.get("logging.googleapis.com/trace").getAsString()),
+                    () -> assertEquals(spanId, logEntryJson.get("logging.googleapis.com/spanId").getAsString()),
+                    () -> assertTrue(logEntryJson.get("logging.googleapis.com/trace_sampled").getAsBoolean()));
+
+            JsonObject labels = logEntryJson.get("logging.googleapis.com/labels").getAsJsonObject();
+            assertNotNull(labels);
+            assertAll(
+                    () -> assertEquals("INFO", labels.get("levelName").getAsString()),
+                    () -> assertEquals("800", labels.get("levelValue").getAsString()),
+                    () -> assertEquals(getClass().getName(), labels.get("loggerName").getAsString()));
+
+            JsonObject log = logEntryJson.get("log").getAsJsonObject();
+            assertNotNull(log);
+            assertAll(
+                    () -> assertEquals("INFO", log.get("level").getAsString()),
+                    () -> assertEquals(getClass().getName(), log.get("logger").getAsString()));
+
+            JsonObject origin = log.get("origin").getAsJsonObject();
+            assertNotNull(origin);
+            JsonObject classOrigin = origin.get("class").getAsJsonObject();
+            assertNotNull(classOrigin);
+            assertEquals(getClass().getName(), classOrigin.get("name").getAsString());
+            assertEquals(String.format("%s.0", sourceLineNumber), classOrigin.get("line").getAsNumber().toString());
+        }
+
+    }
+
+    private ArcContainer createArcContainer(String traceId, String spanId) {
+        ArcContainer container = Mockito.mock(ArcContainer.class);
+        InstanceHandle<TraceInfoExtractor> traceInfoInstanceHandler = Mockito.mock(InstanceHandle.class);
+        when(traceInfoInstanceHandler.get()).thenReturn(x -> new TraceInfo(traceId, spanId));
+        when(traceInfoInstanceHandler.isAvailable()).thenReturn(true);
+        when(container.instance(TraceInfoExtractor.class)).thenReturn(traceInfoInstanceHandler);
+
+        InstanceHandle<Logging> loggingInstanceHandler = Mockito.mock(InstanceHandle.class);
+        Logging logging = Mockito.mock(Logging.class);
+        when(loggingInstanceHandler.get()).thenReturn(logging);
+        when(container.instance(Logging.class)).thenReturn(loggingInstanceHandler);
+        return container;
+    }
+
+    private ExtLogRecord createNewInfoLogRecord(String msg, int sourceLineNumber) {
+        ExtLogRecord extLogRecord = new ExtLogRecord(Level.INFO, msg, getClass().getName());
+        extLogRecord.setSourceClassName(getClass().getName());
+        extLogRecord.setSourceLineNumber(sourceLineNumber);
+        return extLogRecord;
+    }
+
+    private LoggingConfiguration createJsonStdoutLoggingConfiguration(String projectId) {
+        LoggingConfiguration c = Mockito.mock(LoggingConfiguration.class);
+
+        LoggingConfiguration.MDCConfig mdc = Mockito.mock(LoggingConfiguration.MDCConfig.class);
+        when(mdc.included()).thenReturn(true);
+
+        LoggingConfiguration.StackTraceConfig stackTrace = Mockito.mock(LoggingConfiguration.StackTraceConfig.class);
+        when(stackTrace.included()).thenReturn(true);
+
+        LoggingConfiguration.ParametersConfig parameters = Mockito.mock(LoggingConfiguration.ParametersConfig.class);
+        when(parameters.included()).thenReturn(true);
+        when(parameters.fieldName()).thenReturn("parameters");
+
+        LoggingConfiguration.StructuredConfig structured = Mockito.mock(LoggingConfiguration.StructuredConfig.class);
+        when(structured.mdc()).thenReturn(mdc);
+        when(structured.stackTrace()).thenReturn(stackTrace);
+        when(structured.parameters()).thenReturn(parameters);
+        when(c.structured()).thenReturn(structured);
+
+        LoggingConfiguration.GcpTracingConfig gcpTracingConfig = Mockito.mock(LoggingConfiguration.GcpTracingConfig.class);
+        when(gcpTracingConfig.enabled()).thenReturn(true);
+        when(gcpTracingConfig.projectId()).thenReturn(Optional.of(projectId));
+        when(c.gcpTracing()).thenReturn(gcpTracingConfig);
+
+        LoggingConfiguration.ResourceConfig resourceConfig = Mockito.mock(LoggingConfiguration.ResourceConfig.class);
+        when(resourceConfig.type()).thenReturn("generic_node");
+        when(c.resource()).thenReturn(resourceConfig);
+
+        when(c.format()).thenReturn(LoggingConfiguration.LogFormat.JSON);
+        when(c.logTarget()).thenReturn(com.google.cloud.logging.LoggingHandler.LogTarget.STDOUT);
+
+        return c;
+    }
+}

--- a/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
+++ b/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
@@ -79,13 +79,6 @@ class LoggingHandlerTest {
                     () -> assertEquals(spanId, logEntryJson.get("logging.googleapis.com/spanId").getAsString()),
                     () -> assertTrue(logEntryJson.get("logging.googleapis.com/trace_sampled").getAsBoolean()));
 
-            JsonObject labels = logEntryJson.get("logging.googleapis.com/labels").getAsJsonObject();
-            assertNotNull(labels);
-            assertAll(
-                    () -> assertEquals("INFO", labels.get("levelName").getAsString()),
-                    () -> assertEquals("800", labels.get("levelValue").getAsString()),
-                    () -> assertEquals(getClass().getName(), labels.get("loggerName").getAsString()));
-
             JsonObject log = logEntryJson.get("log").getAsJsonObject();
             assertNotNull(log);
             assertAll(

--- a/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
+++ b/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
@@ -32,6 +32,7 @@ import io.quarkus.arc.InstanceHandle;
  */
 class LoggingHandlerTest {
 
+    private final PrintStream standardOut = System.out;
     private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
 
     @BeforeEach
@@ -43,7 +44,7 @@ class LoggingHandlerTest {
     @AfterEach
     void tearDown() {
         // Reset System.out after test complete
-        System.setOut(System.out);
+        System.setOut(standardOut);
     }
 
     @Test


### PR DESCRIPTION
These changes address [issue 674](https://github.com/quarkiverse/quarkus-google-cloud-services/issues/674) by ensuring that the span id and sampled properties are set on the `LogEntry.builder` (without these settings it is not possible to exploit the feature of GCP console where a log entry can be used to launch inspection of the trace corresponding to that log (and vice versa).

These changes have been tested in a native-build Quarkus microservice (running Quarkus 3.11.3).