### PR TITLE
678: register Severity enum for reflection

### DIFF
--- a/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
+++ b/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.googlecloudservices.logging.deployment;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.quarkiverse.googlecloudservices.logging.runtime.LoggingConfiguration;
 import io.quarkiverse.googlecloudservices.logging.runtime.TraceInfoExtractor;
 import io.quarkiverse.googlecloudservices.logging.runtime.cdi.LoggingProducer;
@@ -11,6 +14,7 @@ import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.LogHandlerBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class LoggingBuildSteps {
 
@@ -37,5 +41,15 @@ public class LoggingBuildSteps {
     @Record(ExecutionTime.RUNTIME_INIT)
     public LogHandlerBuildItem handler(LoggingConfiguration config, LoggingHandlerFactory factory) {
         return new LogHandlerBuildItem(factory.create(config));
+    }
+
+    @BuildStep
+    public List<ReflectiveClassBuildItem> registerReflectiveClasses() {
+        List<ReflectiveClassBuildItem> items = new ArrayList<>();
+        // Required for native builds as LoggingHandler uses Gson to serialize severity values
+        items.add(ReflectiveClassBuildItem.builder("com.google.cloud.logging.Severity")
+                .fields(true)
+                .build());
+        return items;
     }
 }


### PR DESCRIPTION
Register `Severity` enum for reflection so native app builds don't need to do this themselves. This addresses issue [678](https://github.com/quarkiverse/quarkus-google-cloud-services/issues/678).

This has been tested by native building a Quarkus app and verifying that the correct severity levels appear in the GCP logging console.