### PR TITLE
provide an extension mechanism for adding custom labels to gcp logs

### DIFF
--- a/docs/modules/ROOT/pages/logging.adoc
+++ b/docs/modules/ROOT/pages/logging.adoc
@@ -143,7 +143,7 @@ By default, this will also be set on the Google Cloud Operations log entry as a 
 
 === Custom Labels
 
-In order to include additional labels in the log, you must bind a `LogRecordLabelSupplier` to the CDI context, e.g.:
+In order to include additional labels in the log, you must bind a `LogRecordLabelExtractor` to the CDI context, e.g.:
 
 [source,java]
 ----
@@ -155,14 +155,14 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.jboss.logmanager.ExtLogRecord;
 
-import io.quarkiverse.googlecloudservices.logging.runtime.LogRecordLabelSupplier;
+import io.quarkiverse.googlecloudservices.logging.runtime.LogRecordLabelExtractor;
 
 @ApplicationScoped
-public class LogLabelSupplier implements LogRecordLabelSupplier {
+public class LogLabelExtractor implements LogRecordLabelExtractor {
 
     @Override
     public Map<String, String> getCustomLabels(ExtLogRecord extLogRecord) {
-        return Map.of(/* something, something */);
+        return Map.of(/* some label, some value */);
     }
 }
 ----

--- a/docs/modules/ROOT/pages/logging.adoc
+++ b/docs/modules/ROOT/pages/logging.adoc
@@ -141,6 +141,34 @@ By default, this will also be set on the Google Cloud Operations log entry as a 
 
 * `quarkus.google.cloud.logging.gcp-tracing.enabled=[true|false]`
 
+=== Custom Labels
+
+In order to include additional labels in the log, you must bind a `LogRecordLabelSupplier` to the CDI context, e.g.:
+
+[source,java]
+----
+package mypackage;
+
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+import io.quarkiverse.googlecloudservices.logging.runtime.LogRecordLabelSupplier;
+
+@ApplicationScoped
+public class LogLabelSupplier implements LogRecordLabelSupplier {
+
+    @Override
+    public Map<String, String> getCustomLabels(ExtLogRecord extLogRecord) {
+        return Map.of(/* something, something */);
+    }
+}
+----
+
+This will include additional labels in the log.
+
 == Injecting GCP Logging
 You can inject a `com.google.cloud.logging.Logging` instance directly. If you do so, the configuration for the project to use, still apply.
 

--- a/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
+++ b/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
@@ -3,6 +3,7 @@ package io.quarkiverse.googlecloudservices.logging.deployment;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.quarkiverse.googlecloudservices.logging.runtime.LogRecordLabelSupplier;
 import io.quarkiverse.googlecloudservices.logging.runtime.LoggingConfiguration;
 import io.quarkiverse.googlecloudservices.logging.runtime.TraceInfoExtractor;
 import io.quarkiverse.googlecloudservices.logging.runtime.cdi.LoggingProducer;
@@ -34,7 +35,8 @@ public class LoggingBuildSteps {
     public UnremovableBeanBuildItem helperClasses() {
         return UnremovableBeanBuildItem.beanTypes(
                 TraceInfoExtractor.class,
-                LoggingConfiguration.class);
+                LoggingConfiguration.class,
+                LogRecordLabelSupplier.class);
     }
 
     @BuildStep

--- a/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
+++ b/logging/deployment/src/main/java/io/quarkiverse/googlecloudservices/logging/deployment/LoggingBuildSteps.java
@@ -3,7 +3,7 @@ package io.quarkiverse.googlecloudservices.logging.deployment;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.quarkiverse.googlecloudservices.logging.runtime.LogRecordLabelSupplier;
+import io.quarkiverse.googlecloudservices.logging.runtime.LogRecordLabelExtractor;
 import io.quarkiverse.googlecloudservices.logging.runtime.LoggingConfiguration;
 import io.quarkiverse.googlecloudservices.logging.runtime.TraceInfoExtractor;
 import io.quarkiverse.googlecloudservices.logging.runtime.cdi.LoggingProducer;
@@ -36,7 +36,7 @@ public class LoggingBuildSteps {
         return UnremovableBeanBuildItem.beanTypes(
                 TraceInfoExtractor.class,
                 LoggingConfiguration.class,
-                LogRecordLabelSupplier.class);
+                LogRecordLabelExtractor.class);
     }
 
     @BuildStep

--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LogRecordLabelExtractor.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LogRecordLabelExtractor.java
@@ -6,9 +6,9 @@ import org.jboss.logmanager.ExtLogRecord;
 
 /**
  * Bind an instance of this interface to include additional labels
- * in the log record. You should only bind one supplier in the CDI context.
+ * in the log record. You should only bind one extractor in the CDI context.
  */
-public interface LogRecordLabelSupplier {
+public interface LogRecordLabelExtractor {
 
     /**
      * Supply additional labels for a log record.

--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LogRecordLabelSupplier.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LogRecordLabelSupplier.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.googlecloudservices.logging.runtime;
+
+import java.util.Map;
+
+import org.jboss.logmanager.ExtLogRecord;
+
+/**
+ * Bind an instance of this interface to include additional labels
+ * in the log record. You should only bind one supplier in the CDI context.
+ */
+public interface LogRecordLabelSupplier {
+
+    /**
+     * Supply additional labels for a log record.
+     *
+     * @param record Record for which labels can be supplied, never null
+     * @return a map of additional label values, may return null or empty but neither
+     *         keys nor values therein should be null
+     */
+    Map<String, String> getCustomLabels(ExtLogRecord record);
+
+}

--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandler.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandler.java
@@ -34,7 +34,7 @@ public class LoggingHandler extends ExtHandler {
     private WriteOption[] defaultWriteOptions;
     private InternalHandler internalHandler;
     private TraceInfoExtractor traceExtractor;
-    private LogRecordLabelSupplier logRecordLabelSupplier;
+    private LogRecordLabelExtractor logRecordLabelExtractor;
 
     public LoggingHandler(LoggingConfiguration config) {
         this.config = config;
@@ -85,7 +85,7 @@ public class LoggingHandler extends ExtHandler {
                     .setSeverity(LevelTransformer.toSeverity(record.getLevel()))
                     .setTimestamp(record.getInstant());
 
-            final Map<String, String> customLabels = logRecordLabelSupplier.getCustomLabels(record);
+            final Map<String, String> customLabels = logRecordLabelExtractor.getCustomLabels(record);
 
             if (customLabels != null) {
                 for (Map.Entry<String, String> entry : customLabels.entrySet()) {
@@ -130,18 +130,18 @@ public class LoggingHandler extends ExtHandler {
             initInternalHandler();
             // init trace extractor
             initTraceExtractor();
-            // init log record label supplier
-            initLogRecordLabelSupplier();
+            // init log record label extractor
+            initLogRecordLabelExtractor();
         }
         return log;
     }
 
-    private void initLogRecordLabelSupplier() {
-        InstanceHandle<LogRecordLabelSupplier> handle = Arc.container().instance(LogRecordLabelSupplier.class);
+    private void initLogRecordLabelExtractor() {
+        InstanceHandle<LogRecordLabelExtractor> handle = Arc.container().instance(LogRecordLabelExtractor.class);
         if (handle.isAvailable()) {
-            this.logRecordLabelSupplier = handle.get();
+            this.logRecordLabelExtractor = handle.get();
         } else {
-            this.logRecordLabelSupplier = s -> Collections.emptyMap();
+            this.logRecordLabelExtractor = s -> Collections.emptyMap();
         }
     }
 

--- a/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
+++ b/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
@@ -110,10 +110,10 @@ class LoggingHandlerTest {
         when(traceInfoInstanceHandler.isAvailable()).thenReturn(true);
         when(container.instance(TraceInfoExtractor.class)).thenReturn(traceInfoInstanceHandler);
 
-        InstanceHandle<LogRecordLabelSupplier> logRecordLabelSupplierInstanceHandler = Mockito.mock(InstanceHandle.class);
-        when(logRecordLabelSupplierInstanceHandler.get()).thenReturn(x -> Map.of("label1", "value1", "label2", "value2"));
-        when(logRecordLabelSupplierInstanceHandler.isAvailable()).thenReturn(true);
-        when(container.instance(LogRecordLabelSupplier.class)).thenReturn(logRecordLabelSupplierInstanceHandler);
+        InstanceHandle<LogRecordLabelExtractor> logRecordLabelExtractorInstanceHandle = Mockito.mock(InstanceHandle.class);
+        when(logRecordLabelExtractorInstanceHandle.get()).thenReturn(x -> Map.of("label1", "value1", "label2", "value2"));
+        when(logRecordLabelExtractorInstanceHandle.isAvailable()).thenReturn(true);
+        when(container.instance(LogRecordLabelExtractor.class)).thenReturn(logRecordLabelExtractorInstanceHandle);
 
         InstanceHandle<Logging> loggingInstanceHandler = Mockito.mock(InstanceHandle.class);
         Logging logging = Mockito.mock(Logging.class);

--- a/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
+++ b/logging/runtime/src/test/java/io/quarkiverse/googlecloudservices/logging/runtime/LoggingHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Level;
@@ -79,6 +80,13 @@ class LoggingHandlerTest {
                     () -> assertEquals(spanId, logEntryJson.get("logging.googleapis.com/spanId").getAsString()),
                     () -> assertTrue(logEntryJson.get("logging.googleapis.com/trace_sampled").getAsBoolean()));
 
+            JsonObject labels = logEntryJson.get("logging.googleapis.com/labels").getAsJsonObject();
+            assertNotNull(labels);
+            assertAll(
+                    () -> assertEquals(2, labels.entrySet().size()),
+                    () -> assertEquals("value1", labels.get("label1").getAsString()),
+                    () -> assertEquals("value2", labels.get("label2").getAsString()));
+
             JsonObject log = logEntryJson.get("log").getAsJsonObject();
             assertNotNull(log);
             assertAll(
@@ -101,6 +109,11 @@ class LoggingHandlerTest {
         when(traceInfoInstanceHandler.get()).thenReturn(x -> new TraceInfo(traceId, spanId));
         when(traceInfoInstanceHandler.isAvailable()).thenReturn(true);
         when(container.instance(TraceInfoExtractor.class)).thenReturn(traceInfoInstanceHandler);
+
+        InstanceHandle<LogRecordLabelSupplier> logRecordLabelSupplierInstanceHandler = Mockito.mock(InstanceHandle.class);
+        when(logRecordLabelSupplierInstanceHandler.get()).thenReturn(x -> Map.of("label1", "value1", "label2", "value2"));
+        when(logRecordLabelSupplierInstanceHandler.isAvailable()).thenReturn(true);
+        when(container.instance(LogRecordLabelSupplier.class)).thenReturn(logRecordLabelSupplierInstanceHandler);
 
         InstanceHandle<Logging> loggingInstanceHandler = Mockito.mock(InstanceHandle.class);
         Logging logging = Mockito.mock(Logging.class);


### PR DESCRIPTION
This introduces an extension interface `LogRecordLabelExtractor` which can be implemented to allow custom labels to be added to each log entry when logging to gcp.