### PR TITLE
Improve test containers startup speed

### DIFF
--- a/docs/modules/ROOT/pages/firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/firebase-devservices.adoc
@@ -112,7 +112,7 @@ quarkusDev {
 This extension builds a custom Docker image to execute the firebase emulators. To reduce startup times, an aggressive
 caching strategy is used. The extension will build an internal base image (called
 `localhost/testcontainers/firebase-base:{firebase-version}`) and will only rebuild this image if it cannot be found.
-This means if you need to image to be regenerated, you manually need remove the docker image.
+If you need the image to be regenerated, you manually need to remove the docker image.
 
 Currently the base image builder uses the following steps:
 - Select the base image (based on the image name, see below)

--- a/docs/modules/ROOT/pages/firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/firebase-devservices.adoc
@@ -107,6 +107,23 @@ quarkusDev {
 }
 ----
 
+== Base image caching
+
+This extension builds a custom Docker image to execute the firebase emulators. To reduce startup times, an aggressive
+caching strategy is used. The extension will build an internal base image (called
+`localhost/testcontainers/firebase-base:{firebase-version}`) and will only rebuild this image if it cannot be found.
+This means if you need to image to be regenerated, you manually need remove the docker image.
+
+Currently the base image builder uses the following steps:
+- Select the base image (based on the image name, see below)
+- Clean up the image and install needed dependencies
+- Create a user and group if needed
+- Assign ownership to the selected user/group
+- Switch to the specified user
+- Download and cache all Firebase emulators
+
+This means that if you need to alter any of the steps previously mentioned, you need to remove the mentioned base image.
+
 == Custom Docker image
 
 To run the emulators, a custom Docker image is build on the fly to run the Firebase emulators. This image is based on a NodeJS based image (refer to the configuration of the default value of `quarkus.google.cloud.firebase.devservice.image-name` to see the base image).

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
@@ -7,7 +7,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import com.github.dockerjava.api.DockerClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -18,6 +17,8 @@ import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.images.builder.dockerfile.DockerfileBuilder;
+
+import com.github.dockerjava.api.DockerClient;
 
 /**
  * Testcontainers container to run Firebase emulators from Docker.

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseVersionResolver.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseVersionResolver.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.googlecloudservices.firebase.deployment.testcontainers;
+
+import com.google.api.client.json.gson.GsonFactory;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Resolves the version of the firebase tools based on the NPM registry in case version
+ * "latest" is used.
+ */
+public class FirebaseVersionResolver {
+
+    public String resolveVersion(String version) throws IOException {
+        if (!Objects.equals(version, "latest")) {
+            return version;
+        }
+
+        try (var httpClient = HttpClientBuilder.create().build()) {
+            var request = new HttpGet("https://registry.npmjs.org/firebase-tools/latest");
+            var response = httpClient.execute(request);
+            if (response.getStatusLine().getStatusCode() != 200) {
+                throw new IOException("Unexpected response code " + response.getStatusLine().getStatusCode());
+            }
+            GsonFactory gsonFactory = GsonFactory.getDefaultInstance();
+
+            try (var json = gsonFactory.createJsonParser(response.getEntity().getContent())) {
+                var npmResponse = json.parse(Map.class);
+                if (!npmResponse.containsKey("version") || npmResponse.get("version") == null) {
+                    throw new IOException("Unexpected response from NPM API");
+                }
+
+                return npmResponse.get("version").toString();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently emulators are downloaded on every startup, increasing startup time.

Lets try to avoid that and make the emulator startup way faster