### PR TITLE
[GCP Logging] GCP project id from quarkus config is not considered

### DIFF
--- a/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/cdi/LoggingProducer.java
+++ b/logging/runtime/src/main/java/io/quarkiverse/googlecloudservices/logging/runtime/cdi/LoggingProducer.java
@@ -36,7 +36,7 @@ public class LoggingProducer {
     public Logging create() {
         GcpBootstrapConfiguration gcpConfiguration = gcpConfigHolder.getBootstrapConfig();
         String projectId = gcpConfiguration.projectId().orElse(null);
-        Logging log = LoggingOptions.getDefaultInstance().toBuilder()
+        Logging log = LoggingOptions.newBuilder()
                 .setCredentials(googleCredentials)
                 .setProjectId(projectId)
                 .build()


### PR DESCRIPTION
The `quarkus.google.cloud.project-id` config property  is not considered when using LoggingOptions default instance.

I got the following stacktrace even though I specified the `quarkus.google.cloud.project-id` config property and even tried to use `QUARKUS_GOOGLE_CLOUD_PROJECT_ID` as env variable:

```bash
LogManager error of type WRITE_FAILURE: Failed to write logs
java.lang.IllegalArgumentException: A project ID is required for this service but could not be determined from the builder or the environment.  Please set a project ID using the builder.
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:143)
        at com.google.cloud.ServiceOptions.<init>(ServiceOptions.java:340)
        at com.google.cloud.logging.LoggingOptions.<init>(LoggingOptions.java:118)
        at com.google.cloud.logging.LoggingOptions$Builder.build(LoggingOptions.java:112)
        at com.google.cloud.logging.LoggingOptions.getDefaultInstance(LoggingOptions.java:57)
        at io.quarkiverse.googlecloudservices.logging.runtime.cdi.LoggingProducer.create(LoggingProducer.java:39)
```

The problem is that `LoggingOptions.getDefaultInstance()` is already trying to find a project id in various ways (but not considering `quarkus.google.cloud.project-id`) and if that fails the call to the inherited `ServiceOptions` constructor will raise an `IllegalArgumentException` due to this:

```
    @InternalApi("This class should only be extended within google-cloud-java")
    protected ServiceOptions(Class<? extends ServiceFactory<ServiceT, OptionsT>> serviceFactoryClass, Class<? extends ServiceRpcFactory<OptionsT>> rpcFactoryClass, Builder<ServiceT, OptionsT, ?> builder, ServiceDefaults<ServiceT, OptionsT> serviceDefaults) {
        this.projectId = builder.projectId != null ? builder.projectId : this.getDefaultProject();
        if (this.projectIdRequired()) {
            Preconditions.checkArgument(this.projectId != null, "A project ID is required for this service but could not be determined from the builder or the environment.  Please set a project ID using the builder.");
        }
```

So in my case the `builder.projectId` is null and therefore the `IllegalArgumentException` is thrown.

I resolved the issue on my side by adding `GOOGLE_CLOUD_PROJECT=my-gcp-project-id` as system environment variable, but IMHO your `GcpBootstrapConfiguration`, aka `quarkus.google.cloud.project-id` config property, should also be considered here ;)