### PR TITLE
Fixed issue with running as a group already existing in the docker image

### DIFF
--- a/firebase-devservices/deployment/src/main/resources/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/Dockerfile.base
+++ b/firebase-devservices/deployment/src/main/resources/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/Dockerfile.base
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+ARG USER_ID
+ARG GROUP_ID
+ARG FIREBASE_VERSION
+
+RUN apk --no-cache add openjdk17-jre bash curl openssl gettext nano nginx sudo && \
+    npm cache clean --force && \
+    npm i -g firebase-tools@${FIREBASE_VERSION} && \
+    deluser nginx && delgroup abuild && delgroup ping && \
+    mkdir -p /srv/firebase && \
+    mkdir -p /srv/firebase/data && \
+    mkdir -p /srv/firebase//emulator-data && \
+    chmod 777 -R /srv/*
+
+COPY user-add.sh /srv/
+RUN chmod +x /srv/user-add.sh
+RUN /srv/user-add.sh ${USER_ID} ${GROUP_ID}
+
+RUN chown ${USER_ID}:${GROUP_ID} -R /srv/*
+USER "${USER_ID}:${GROUP_ID}"
+
+RUN firebase setup:emulators:database
+RUN firebase setup:emulators:firestore
+RUN firebase setup:emulators:pubsub
+RUN firebase setup:emulators:storage
+RUN firebase setup:emulators:ui

--- a/firebase-devservices/deployment/src/main/resources/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/user-add.sh
+++ b/firebase-devservices/deployment/src/main/resources/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/user-add.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+user_exists(){ id "$1" &>/dev/null; }
+group_exists(){ getent group "$1" &>/dev/null; }
+group_name(){ getent group "$1" | cut -d ':' -f 1; }
+
+user="$1"
+group="$2"
+
+echo "Running as user $user : $group , checking if they need to be added..."
+
+if group_exists "$group" ; then
+  echo "Group already exists, reusing existing group"
+else
+  addgroup -g "$group" runner
+fi
+
+groupName=$(group_name "$group")
+
+echo "Running as group name $groupName"
+
+if user_exists "$user" ; then
+  echo "User already exists, skipping adding"
+else
+  adduser -u "$user" -G "$groupName" -D -h /srv/firebase runner
+fi


### PR DESCRIPTION
There was an issue when an already existing group was used in the docker image. The logic tried to re-add the existing group, which of course failed the docker build. This especially manifested after the recent auto-uid-gid change. With this setup, this is fixed, as the logic first checks if the user exists.

Also, I extracted creation of the base image to a Dockerfile. This reduces the Java logic and is more easier to maintain, as it is now just a regular Dockerfile with some build arguments.

Moving the rest of the logic to a Dockerfile didn't seem the way to go, as this is way less straightforward in it logic (way more optional paths).