### PR TITLE
Use an old version of the cloud-dsk image as latest has issues

### DIFF
--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -49,3 +49,6 @@ quarkus.google.cloud.logging.resource.label.node_id=192.168.0.2
 quarkus.google.cloud.logging.structured.stack-trace.included=true
 quarkus.google.cloud.logging.gcp-tracing.enabled=false
 quarkus.google.cloud.logging.format=json
+
+## The latest cloud-sdk image has issues, use 522.0.0 for now
+quarkus.google.cloud.firestore.devservice.image-name = gcr.io/google.com/cloudsdktool/google-cloud-cli:522.0.0


### PR DESCRIPTION
When running the Firestore emulator, an error is displayed