### PR TITLE
Fix setup of emulators.

### DIFF
--- a/firebase-devservices/deployment/src/main/resources/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/Dockerfile.base
+++ b/firebase-devservices/deployment/src/main/resources/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/Dockerfile.base
@@ -23,6 +23,7 @@ RUN /srv/user-add.sh ${USER_ID} ${GROUP_ID}
 RUN chown ${USER_ID}:${GROUP_ID} -R /srv/*
 USER "${USER_ID}:${GROUP_ID}"
 
+WORKDIR /srv/firebase
 RUN firebase setup:emulators:database
 RUN firebase setup:emulators:firestore
 RUN firebase setup:emulators:pubsub


### PR DESCRIPTION
It seems the new setup of firebase-tools now writes to the current directory. By default, this is the root directory, for which the running user does not have permissions. By settings the workdir to /srv/firebase, downloading emulators should work.