### PR TITLE
support regional secrets

### DIFF
--- a/secret-manager/runtime/src/test/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/config/SecretManagerConfigUtilsTest.java
+++ b/secret-manager/runtime/src/test/java/io/quarkiverse/googlecloudservices/secretmanager/runtime/config/SecretManagerConfigUtilsTest.java
@@ -76,4 +76,26 @@ public class SecretManagerConfigUtilsTest {
         assertThat(secretIdentifier.getSecret()).isEqualTo("the-secret");
         assertThat(secretIdentifier.getSecretVersion()).isEqualTo("3");
     }
+
+    @Test
+    public void testRegionalSecret_projectLocationSecret() {
+        String property = "sm//projects/my-project/locations/the-location/secrets/the-secret";
+        SecretVersionName secretIdentifier = SecretManagerConfigUtils.getSecretVersionName(property, DEFAULT_PROJECT);
+
+        assertThat(secretIdentifier.getProject()).isEqualTo("my-project");
+        assertThat(secretIdentifier.getLocation()).isEqualTo("the-location");
+        assertThat(secretIdentifier.getSecret()).isEqualTo("the-secret");
+        assertThat(secretIdentifier.getSecretVersion()).isEqualTo("latest");
+    }
+
+    @Test
+    public void testRegionalSecret_projectLocationSecretVersion() {
+        String property = "sm//projects/my-project/locations/the-location/secrets/the-secret/versions/4";
+        SecretVersionName secretIdentifier = SecretManagerConfigUtils.getSecretVersionName(property, DEFAULT_PROJECT);
+
+        assertThat(secretIdentifier.getProject()).isEqualTo("my-project");
+        assertThat(secretIdentifier.getLocation()).isEqualTo("the-location");
+        assertThat(secretIdentifier.getSecret()).isEqualTo("the-secret");
+        assertThat(secretIdentifier.getSecretVersion()).isEqualTo("4");
+    }
 }


### PR DESCRIPTION
Related to issue: https://github.com/quarkiverse/quarkus-google-cloud-services/issues/919

I have made a draft of what support for regional secrets might look like. 

I am however, not sure how the short-hand secrets should look like for regional secrets. Any idea? Or do Google have standards for this?

