### PR TITLE
Implemented support to add additional environment variables to the Firebase devservice. 

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices.adoc
@@ -219,6 +219,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars[`quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+List of additional environment variables and values which can be passed into the docker image. These variables can be picked up by some webframeworks or functions (see the firebase documentation). This feature can e.g. be used to pass in for example the port the Quarkus application is exposing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token[`quarkus.google.cloud.devservices.firebase.emulator.cli.token`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.token+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices_quarkus.google.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices_quarkus.google.adoc
@@ -219,6 +219,27 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |
 
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars[`quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+List of additional environment variables and values which can be passed into the docker image. These variables can be picked up by some webframeworks or functions (see the firebase documentation). This feature can e.g. be used to pass in for example the port the Quarkus application is exposing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|
+
 a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token[`quarkus.google.cloud.devservices.firebase.emulator.cli.token`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.token+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub.adoc
@@ -241,5 +241,47 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-parallel-stream-count]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-parallel-stream-count[`quarkus.google.cloud.pubsub.pull.parallel-stream-count`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.pull.parallel-stream-count+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of concurrent streams to use for pull subscriptions. Defaults to 1 which is the same as the base PubSub library.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_PARALLEL_STREAM_COUNT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_PARALLEL_STREAM_COUNT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++1+++`
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-stream-concurrency]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-stream-concurrency[`quarkus.google.cloud.pubsub.pull.stream-concurrency`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.pull.stream-concurrency+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of concurrent messages to process per stream. Defaults to 5 which is the same as the base PubSub library.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_STREAM_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_STREAM_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub_quarkus.google.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub_quarkus.google.adoc
@@ -241,5 +241,47 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-parallel-stream-count]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-parallel-stream-count[`quarkus.google.cloud.pubsub.pull.parallel-stream-count`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.pull.parallel-stream-count+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of concurrent streams to use for pull subscriptions. Defaults to 1 which is the same as the base PubSub library.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_PARALLEL_STREAM_COUNT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_PARALLEL_STREAM_COUNT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++1+++`
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-stream-concurrency]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-pull-stream-concurrency[`quarkus.google.cloud.pubsub.pull.stream-concurrency`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.pull.stream-concurrency+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Number of concurrent messages to process per stream. Defaults to 5 which is the same as the base PubSub library.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_STREAM_CONCURRENCY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PULL_STREAM_CONCURRENCY+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|`+++5+++`
+
 |===
 

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceConfig.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.googlecloudservices.firebase.deployment;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -173,6 +174,13 @@ public interface FirebaseDevServiceConfig {
                  * Pipe Stedd of the container to the Quarkus logging
                  */
                 Optional<Boolean> followStdErr();
+
+                /**
+                 * List of additional environment variables and values which can be passed into the docker image. These
+                 * variables can be picked up by some webframeworks or functions (see the firebase documentation).
+                 * This feature can e.g. be used to pass in for example the port the Quarkus application is exposing.
+                 */
+                Map<String, String> envVars();
 
             }
 

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilder.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilder.java
@@ -76,6 +76,7 @@ public class FirebaseEmulatorConfigBuilder {
         docker.followStdOut().ifPresent(dockerConfig::followStdOut);
         docker.followStdErr().ifPresent(dockerConfig::followStdErr);
         dockerConfig.useSharedNetwork(this.useSharedNetwork);
+        dockerConfig.withEnvVars(docker.envVars());
 
         dockerConfig.done();
     }

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
@@ -169,6 +169,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             boolean followStdOut,
             boolean followStdErr,
             boolean useSharedNetwork,
+            Map<String, String> envVars,
             Consumer<FirebaseEmulatorContainer> afterStart) {
 
         /**
@@ -181,6 +182,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                 true,
                 true,
                 false,
+                new HashMap<>(),
                 null);
     }
 
@@ -484,6 +486,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         Builder.this.dockerConfig.followStdOut(),
                         Builder.this.dockerConfig.followStdErr(),
                         Builder.this.dockerConfig.useSharedNetwork(),
+                        Builder.this.dockerConfig.envVars(),
                         Builder.this.dockerConfig.afterStart());
                 return this;
             }
@@ -516,6 +519,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         Builder.this.dockerConfig.followStdOut(),
                         Builder.this.dockerConfig.followStdErr(),
                         Builder.this.dockerConfig.useSharedNetwork(),
+                        Builder.this.dockerConfig.envVars(),
                         Builder.this.dockerConfig.afterStart());
                 return this;
             }
@@ -548,6 +552,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         Builder.this.dockerConfig.followStdOut(),
                         Builder.this.dockerConfig.followStdErr(),
                         Builder.this.dockerConfig.useSharedNetwork(),
+                        Builder.this.dockerConfig.envVars(),
                         Builder.this.dockerConfig.afterStart());
                 return this;
             }
@@ -589,6 +594,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         followStdOut,
                         Builder.this.dockerConfig.followStdErr(),
                         Builder.this.dockerConfig.useSharedNetwork(),
+                        Builder.this.dockerConfig.envVars(),
                         Builder.this.dockerConfig.afterStart());
                 return this;
             }
@@ -607,6 +613,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         Builder.this.dockerConfig.followStdOut(),
                         followStdErr,
                         Builder.this.dockerConfig.useSharedNetwork(),
+                        Builder.this.dockerConfig.envVars(),
                         Builder.this.dockerConfig.afterStart());
                 return this;
             }
@@ -625,6 +632,27 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         Builder.this.dockerConfig.followStdOut(),
                         Builder.this.dockerConfig.followStdErr(),
                         useSharedNetwork,
+                        Builder.this.dockerConfig.envVars(),
+                        Builder.this.dockerConfig.afterStart());
+                return this;
+            }
+
+            /**
+             * Add additional environment variables to the docker image. These can be picked up by
+             * some webframeworks to pass in configuration.
+             *
+             * @param envVars The environment variables
+             * @return THe builder
+             */
+            public DockerConfigBuilder withEnvVars(Map<String, String> envVars) {
+                Builder.this.dockerConfig = new DockerConfig(
+                        Builder.this.dockerConfig.imageName(),
+                        Builder.this.dockerConfig.userId(),
+                        Builder.this.dockerConfig.groupId(),
+                        Builder.this.dockerConfig.followStdOut(),
+                        Builder.this.dockerConfig.followStdErr(),
+                        Builder.this.dockerConfig.useSharedNetwork(),
+                        new HashMap<>(envVars),
                         Builder.this.dockerConfig.afterStart());
                 return this;
             }
@@ -643,6 +671,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         Builder.this.dockerConfig.followStdOut(),
                         Builder.this.dockerConfig.followStdErr(),
                         Builder.this.dockerConfig.useSharedNetwork(),
+                        Builder.this.dockerConfig.envVars(),
                         afterStart);
                 return this;
             }
@@ -1134,6 +1163,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             this.addFirebaseJson();
             this.includeFirestoreFiles();
             this.includeStorageFiles();
+            this.includeAdditionalEnvironmentVariables();
             this.runExecutable();
 
             return result;
@@ -1397,6 +1427,15 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                 this.dockerBuilder.run("mkdir -p " + containerFunctionsPath(emulatorConfig));
                 this.dockerBuilder.volume(containerFunctionsPath(emulatorConfig));
             }
+        }
+
+        private void includeAdditionalEnvironmentVariables() {
+            LOGGER.debug("Adding additional environment variables in firebase-tools image");
+
+            emulatorConfig.dockerConfig().envVars().forEach((key, value) -> {
+                LOGGER.debug("Adding environment variable {} = {}", key, value);
+                dockerBuilder.env(key, value);
+            });
         }
 
         private void runExecutable() {

--- a/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilderTest.java
+++ b/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilderTest.java
@@ -33,7 +33,8 @@ class FirebaseEmulatorConfigBuilderTest {
                                         Optional.empty(),
                                         false,
                                         Optional.of(false),
-                                        Optional.of(true)),
+                                        Optional.of(true),
+                                        Map.of("TEST", "TestMe")),
                                 new TestCli(
                                         Optional.of("MY_TOKEN"),
                                         Optional.of("-Xmx"),
@@ -86,6 +87,7 @@ class FirebaseEmulatorConfigBuilderTest {
         assertFalse(emulatorConfig.dockerConfig().followStdOut());
         assertTrue(emulatorConfig.dockerConfig().followStdErr());
         assertTrue(emulatorConfig.dockerConfig().useSharedNetwork());
+        assertEquals("TestMe", emulatorConfig.dockerConfig().envVars().get("TEST"));
 
         assertEquals("11.0.0", emulatorConfig.firebaseVersion());
 
@@ -172,7 +174,8 @@ class FirebaseEmulatorConfigBuilderTest {
             Optional<String> dockerGroupEnv,
             boolean autoDetectUserAndGroup,
             Optional<Boolean> followStdOut,
-            Optional<Boolean> followStdErr) implements FirebaseDevServiceConfig.Firebase.Emulator.Docker {
+            Optional<Boolean> followStdErr,
+            Map<String, String> envVars) implements FirebaseDevServiceConfig.Firebase.Emulator.Docker {
     }
 
     record TestCli(


### PR DESCRIPTION
This allows passing in variables (e.g. the quarkus HTTP port) which can be picked up by Web frameworks or functions.

Btw note that the docs require some regeneration for me locally, haven't committed those changes to the other adoc files as this polutes the PR, we might want to regenerate those.