### PR TITLE
PubSub pull concurrency config

### DIFF
--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/PubSubPullConfiguration.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/PubSubPullConfiguration.java
@@ -11,9 +11,6 @@ import io.smallrye.config.WithDefault;
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
 public interface PubSubPullConfiguration {
 
-    public static record PullConfiguration(int parallelStreamCount, int streamConcurrency) {
-    }
-
     /**
      * Number of concurrent streams to use for pull subscriptions. Defaults
      * to 1 which is the same as the base PubSub library.
@@ -28,7 +25,7 @@ public interface PubSubPullConfiguration {
     @WithDefault("5")
     Optional<Integer> streamConcurrency();
 
-    default PullConfiguration toPullConfiguration() {
-        return new PullConfiguration(parallelStreamCount().orElse(1), streamConcurrency().orElse(5));
+    default StreamConfig toStreamConfig() {
+        return new StreamConfig(parallelStreamCount().orElse(1), streamConcurrency().orElse(5));
     }
 }

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/StreamConfig.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/StreamConfig.java
@@ -1,0 +1,10 @@
+package io.quarkiverse.googlecloudservices.pubsub;
+
+/**
+ * @param parallelStreamCount
+ *        Number of concurrent streams to use for pull subscriptions.
+ * @param streamConcurrency
+ *        Number of concurrent messages to process per stream.
+ */
+public record StreamConfig(int parallelStreamCount, int streamConcurrency) {
+}


### PR DESCRIPTION
Pull request for #906: 

* Adds quarkus configuration for no. of parallel streams and the concurrency of each stream. Defaults to the Google PubSub default values - so no change in default behaviour. 
* Adds a dedicated method in `QuarkusPubSub` called `pullSubscriber` for use when different subscribers needs different config. 