### PR TITLE
Update to Google Cloud Library 26.71.0

### DIFF
--- a/bigquery/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigquery/deployment/BigQueryBuildSteps.java
+++ b/bigquery/deployment/src/main/java/io/quarkiverse/googlecloudservices/bigquery/deployment/BigQueryBuildSteps.java
@@ -25,7 +25,7 @@ public class BigQueryBuildSteps {
     public List<RuntimeInitializedClassBuildItem> runtimeInitializedClass() {
         return List.of(
                 new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.BaseAllocator"),
-                new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.DefaultAllocationManagerFactory"),
-                new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.NettyAllocationManager"));
+                new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.netty.DefaultAllocationManagerFactory"),
+                new RuntimeInitializedClassBuildItem("org.apache.arrow.memory.netty.NettyAllocationManager"));
     }
 }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,8 +18,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <google-cloud-sdk.version>26.50.0</google-cloud-sdk.version>
+        <google-cloud-sdk.version>26.71.0</google-cloud-sdk.version>
         <firebase-admin-sdk.version>9.7.0</firebase-admin-sdk.version>
+        <sztd-jni.version>1.5.7-6</sztd-jni.version>
 
         <!-- Dependency convergence issues -->
         <opencensus.version>0.31.1</opencensus.version><!-- mess in google-pubsub and grpc deps; should be rather stable as OpenCensus has been sunsetted already - see https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/862 -->
@@ -42,6 +43,12 @@
                 <groupId>com.google.firebase</groupId>
                 <artifactId>firebase-admin</artifactId>
                 <version>${firebase-admin-sdk.version}</version>
+            </dependency>
+            <!-- Needed for native image build -->
+            <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>${sztd-jni.version}</version>
             </dependency>
 
             <!-- Google Cloud Services common libs-->
@@ -91,6 +98,11 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-annotations</artifactId>
                 <version>${animal-sniffer.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.re2j</groupId>
+                <artifactId>re2j</artifactId>
+                <version>1.8</version>
             </dependency>
 
             <!-- Google Cloud Services Extensions -->

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -46,6 +46,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Needed for native image build -->
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-core</artifactId>

--- a/spanner/runtime/pom.xml
+++ b/spanner/runtime/pom.xml
@@ -30,14 +30,16 @@
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
-                </exclusion>
-                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
@@ -48,6 +50,14 @@
                     <artifactId>animal-sniffer-annotations</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j2-jboss-logmanager</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
26.73.0 causes a dependency issue with Firebase so we had to only upgrade to 26.71.0.

There were multiple native-related issues:
- A missing class from the ZSTD lib so we add this lib for native image compilation.
- Arrow Netty classes changed packages
- Spanner init early Netty shaded libraries: we switch to use Netty shaded instead of Quarkus provided one

Closes #936