### PR TITLE
Extended the documentation of default-log

### DIFF
--- a/docs/modules/ROOT/pages/logging.adoc
+++ b/docs/modules/ROOT/pages/logging.adoc
@@ -73,7 +73,7 @@ public class LoggingResource {
 === Basic
 Currently, the logging system uses a single Google Cloud Operations log and this is a mandatory configuration parameter.
 
-* `quarkus.google.cloud.logging.default-log` - This is the nam of the resource to which the log belogs. See
+* `quarkus.google.cloud.logging.default-log` - This is the name of the resource to which the log belongs. See
   https://docs.cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry[the google docs] for more info. Note that
   currently only a single log id is supported. The logName will always be a project logName and this property does not
   accept forward-slashes.


### PR DESCRIPTION
The original documentation was not really clear on which field on GCP was configured and it's limitations.

fixes #769 