### PR TITLE
docs: escape {firebase-version} attribute reference

### DIFF
--- a/docs/modules/ROOT/pages/firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/firebase-devservices.adoc
@@ -120,7 +120,7 @@ configured. If neither a version is configured, nor a `package.json` file can be
 
 This extension builds a custom Docker image to execute the firebase emulators. To reduce startup times, an aggressive
 caching strategy is used. The extension will build an internal base image (called
-`localhost/testcontainers/firebase-base:{firebase-version}`) and will only rebuild this image if it cannot be found.
+`localhost/testcontainers/firebase-base:\{firebase-version\}`) and will only rebuild this image if it cannot be found.
 If you need the image to be regenerated, you manually need to remove the docker image.
 
 Currently the base image builder uses the following steps:


### PR DESCRIPTION
## Summary
- Escape `{firebase-version}` in the Docker image name `localhost/testcontainers/firebase-base:{firebase-version}` to prevent AsciiDoc from interpreting it as a missing attribute
- This is literal placeholder text, not an AsciiDoc attribute
- Fixes 1 warning during the quarkiverse-docs Antora build

## Test plan
- [ ] Verify the base image caching section renders the Docker image name correctly