### PR TITLE
Keep emulator host ports reachable on shared network

### DIFF
--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceProcessor.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceProcessor.java
@@ -5,6 +5,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.jboss.logging.Logger;
+import org.testcontainers.Testcontainers;
 
 import io.quarkiverse.googlecloudservices.firebase.deployment.testcontainers.FirebaseEmulatorContainer;
 import io.quarkus.deployment.IsNormal;
@@ -46,6 +47,26 @@ public class FirebaseDevServiceProcessor {
             FirebaseEmulatorContainer.Emulator.CLOUD_FIRESTORE, "quarkus.google.cloud.firestore.host-override",
             FirebaseEmulatorContainer.Emulator.CLOUD_STORAGE, "quarkus.google.cloud.storage.host-override",
             FirebaseEmulatorContainer.Emulator.PUB_SUB, "quarkus.google.cloud.pubsub.emulator-host");
+
+    // Additional config properties exposing the emulator endpoints as reachable from any other container
+    // started by Testcontainers in this JVM (e.g. the Playwright browser container, or a containerized
+    // app-under-test), via Testcontainers.exposeHostPorts() + the "host.testcontainers.internal" ambassador
+    // hostname. A container started outside Testcontainers (e.g. via docker-compose) won't have that ambassador
+    // wired up and must instead use the shared-network alias (see FirebaseEmulatorContainer#emulatorUrl).
+    private static final Map<FirebaseEmulatorContainer.Emulator, String> CONTAINER_CONFIG_PROPERTIES = Map.of(
+            FirebaseEmulatorContainer.Emulator.AUTHENTICATION, "quarkus.google.cloud.firebase.auth.container-emulator-host",
+            FirebaseEmulatorContainer.Emulator.EMULATOR_SUITE_UI, "quarkus.google.cloud.firebase.container-emulator-host",
+            FirebaseEmulatorContainer.Emulator.FIREBASE_HOSTING,
+            "quarkus.google.cloud.firebase.hosting.container-emulator-host",
+            FirebaseEmulatorContainer.Emulator.CLOUD_FUNCTIONS, "quarkus.google.cloud.functions.container-emulator-host",
+            FirebaseEmulatorContainer.Emulator.EVENT_ARC, "quarkus.google.cloud.eventarc.container-emulator-host",
+            FirebaseEmulatorContainer.Emulator.REALTIME_DATABASE,
+            "quarkus.google.cloud.firebase.database.container-host-override",
+            FirebaseEmulatorContainer.Emulator.CLOUD_FIRESTORE, "quarkus.google.cloud.firestore.container-host-override",
+            FirebaseEmulatorContainer.Emulator.CLOUD_STORAGE, "quarkus.google.cloud.storage.container-host-override",
+            FirebaseEmulatorContainer.Emulator.PUB_SUB, "quarkus.google.cloud.pubsub.container-emulator-host");
+
+    private static final String HOST_TESTCONTAINERS_INTERNAL = "host.testcontainers.internal";
 
     @BuildStep
     public DevServicesResultBuildItem start(
@@ -290,6 +311,19 @@ public class FirebaseDevServiceProcessor {
             if (emulatorProperties.containsKey(CONFIG_PROPERTIES.get(FirebaseEmulatorContainer.Emulator.CLOUD_FIRESTORE))) {
                 emulatorProperties.put("quarkus.google.cloud.firestore.use-emulator-credentials", "true");
             }
+
+            // Expose the emulator's host-mapped ports to any container started by Testcontainers in this JVM
+            // (e.g. the Playwright browser container), reachable via the "host.testcontainers.internal" ambassador.
+            var configuredEmulators = emulatorContainer.hostEmulatorUrls().keySet();
+            configuredEmulators
+                    .forEach(emulator -> Testcontainers.exposeHostPorts(emulatorContainer.hostMappedPort(emulator)));
+
+            emulatorProperties.putAll(configuredEmulators
+                    .stream()
+                    .filter(CONTAINER_CONFIG_PROPERTIES::containsKey)
+                    .collect(Collectors.toMap(
+                            CONTAINER_CONFIG_PROPERTIES::get,
+                            emulator -> containerEmulatorUrl(emulatorContainer, emulator))));
         }
 
         return emulatorProperties;
@@ -297,6 +331,16 @@ public class FirebaseDevServiceProcessor {
 
     private String configPropertyForEmulator(FirebaseEmulatorContainer.Emulator emulator) {
         return CONFIG_PROPERTIES.get(emulator);
+    }
+
+    /**
+     * Build the URL on which an emulator is reachable from another Testcontainers-managed container, via the
+     * {@code host.testcontainers.internal} ambassador (see {@link Testcontainers#exposeHostPorts(int...)}).
+     */
+    private String containerEmulatorUrl(FirebaseEmulatorContainer emulatorContainer,
+            FirebaseEmulatorContainer.Emulator emulator) {
+        return FirebaseEmulatorContainer.withHttpPrefixIfNeeded(emulator,
+                HOST_TESTCONTAINERS_INTERNAL + ":" + emulatorContainer.hostMappedPort(emulator));
     }
 
     /**

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
@@ -1566,18 +1566,19 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
     public void configure() {
         super.configure();
 
-        if (!useSharedNetwork) {
-            services.keySet()
-                    .forEach(emulator -> {
-                        var exposedPort = services.get(emulator);
-                        // Expose emulatorPort
-                        if (exposedPort.isFixed()) {
-                            addFixedExposedPort(exposedPort.fixedPort(), exposedPort.fixedPort());
-                        } else {
-                            addExposedPort(emulator.internalPort);
-                        }
-                    });
-        }
+        // Always expose/bind ports to the host, even when running on a shared network. This allows the JVM
+        // (which is not part of the Docker network) to keep reaching the emulators via localhost, while
+        // containers on the shared network can additionally reach them via the network alias (see hostName).
+        services.keySet()
+                .forEach(emulator -> {
+                    var exposedPort = services.get(emulator);
+                    // Expose emulatorPort
+                    if (exposedPort.isFixed()) {
+                        addFixedExposedPort(exposedPort.fixedPort(), exposedPort.fixedPort());
+                    } else {
+                        addExposedPort(emulator.internalPort);
+                    }
+                });
 
         waitingFor(Wait.forLogMessage(".*✔  All emulators ready! It is now safe to connect your app.*", 1));
     }
@@ -1587,16 +1588,14 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
     }
 
     /**
-     * Get the various endpoints for the emulators. The map values are in the form of a string "host:port".
+     * Get the various endpoints for the emulators, as reachable from the JVM running the Quarkus application
+     * (i.e. {@code localhost:<mappedPort>}, even when the container is also attached to a shared network).
+     * The map values are in the form of a string "host:port".
      *
      * @return The emulator endpoints
      */
     public Map<Emulator, String> emulatorEndpoints() {
-        return services.keySet()
-                .stream()
-                .collect(Collectors.toMap(
-                        e -> e,
-                        this::getEmulatorEndpoint));
+        return hostEmulatorUrls();
     }
 
     /**
@@ -1606,26 +1605,77 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
      * @return The TCP Port
      */
     public Integer emulatorPort(Emulator emulator) {
-        var exposedPort = services.get(emulator);
-        if (exposedPort.isFixed()) {
-            return exposedPort.fixedPort();
-        } else {
-            if (useSharedNetwork) {
-                return emulator.internalPort;
-            } else {
-                return getMappedPort(emulator.internalPort);
-            }
+        if (useSharedNetwork && !services.get(emulator).isFixed()) {
+            return emulator.internalPort;
         }
+        return hostMappedPort(emulator);
     }
 
     /**
-     * Return the url an emulator is listening on
+     * Return the host-mapped TCP port an emulator is reachable on from the Docker host, regardless of whether
+     * the container is also running on a shared network. Since ports are always exposed to the host (see
+     * {@link #configure()}), this is always backed by a real port mapping.
+     *
+     * @param emulator The emulator
+     * @return The host-mapped TCP port
+     */
+    public Integer hostMappedPort(Emulator emulator) {
+        var exposedPort = services.get(emulator);
+        return exposedPort.isFixed() ? exposedPort.fixedPort() : getMappedPort(emulator.internalPort);
+    }
+
+    /**
+     * Return the url an emulator is listening on, addressed by its shared-network alias. Only resolvable by
+     * other containers attached to the same shared network (see {@link #setupSharedNetworkHost(String)}).
      *
      * @param emulator The emulator
      * @return The url
      */
     public String emulatorUrl(Emulator emulator) {
         return this.hostName + ":" + emulatorPort(emulator);
+    }
+
+    /**
+     * Return the url an emulator is reachable on from the Docker host (i.e. {@code localhost:<mappedPort>}),
+     * usable by the JVM running the Quarkus application even when the container is also attached to a shared
+     * network.
+     *
+     * @param emulator The emulator
+     * @return The host url
+     */
+    public String hostEmulatorUrl(Emulator emulator) {
+        return withHttpPrefixIfNeeded(emulator, this.getHost() + ":" + hostMappedPort(emulator));
+    }
+
+    /**
+     * Some emulators (Realtime Database, Cloud Storage, the Emulator Suite UI) are only usable as an HTTP
+     * endpoint; the others are plain {@code host:port} pairs consumed by gRPC/REST clients. Both
+     * {@link #hostEmulatorUrl(Emulator)} and callers building an equivalent URL for a different host (e.g. the
+     * {@code host.testcontainers.internal} ambassador) should go through this helper to stay consistent.
+     *
+     * @param emulator The emulator the endpoint is for
+     * @param hostPort The {@code host:port} pair to prefix
+     * @return {@code hostPort}, prefixed with {@code http://} if the emulator needs it
+     */
+    public static String withHttpPrefixIfNeeded(Emulator emulator, String hostPort) {
+        if (emulator == Emulator.REALTIME_DATABASE || emulator == Emulator.CLOUD_STORAGE
+                || emulator == Emulator.EMULATOR_SUITE_UI) {
+            return "http://" + hostPort;
+        }
+        return hostPort;
+    }
+
+    /**
+     * Get the host-mapped urls (see {@link #hostEmulatorUrl(Emulator)}) for all configured emulators.
+     *
+     * @return A map {@link Emulator} -> {@link String} of host-reachable emulator endpoints.
+     */
+    public Map<Emulator, String> hostEmulatorUrls() {
+        return services.keySet()
+                .stream()
+                .collect(Collectors.toMap(
+                        e -> e,
+                        this::hostEmulatorUrl));
     }
 
     /**
@@ -1653,14 +1703,4 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
         LOGGER.atLevel(level).log(frame.getUtf8StringWithoutLineEnding());
     }
 
-    private String getEmulatorEndpoint(Emulator emulator) {
-        var endpoint = (useSharedNetwork ? this.hostName : this.getHost()) +
-                ":" + emulatorPort(emulator);
-        if (emulator.equals(Emulator.REALTIME_DATABASE)
-                || emulator.equals(Emulator.CLOUD_STORAGE)
-                || emulator.equals(Emulator.EMULATOR_SUITE_UI)) {
-            endpoint = "http://" + endpoint;
-        }
-        return endpoint;
-    }
 }


### PR DESCRIPTION
When quarkus.devservices.launch-on-shared-network is enabled, the Firebase emulator container previously skipped exposing/binding ports to the Docker host entirely and switched JVM-facing config properties to the shared-network alias (<alias>:<internalPort>). Since the Quarkus JVM process is not part of the Docker network, this made the emulators unreachable from the application itself.

- FirebaseEmulatorContainer now always exposes/binds emulator ports to the host, regardless of shared-network mode, while still joining the shared network and keeping its network alias for in-network container consumers (emulatorUrl/emulatorUrls).
- Added hostMappedPort/hostEmulatorUrl/hostEmulatorUrls, and changed emulatorEndpoints() (which feeds the JVM-facing CONFIG_PROPERTIES) to use these host-mapped, localhost-based endpoints unconditionally. Extracted a shared withHttpPrefixIfNeeded() helper to remove duplicated http:// prefix logic between the host- and container-facing URL builders.
- FirebaseDevServiceProcessor now additionally, when on a shared network, calls Testcontainers.exposeHostPorts() for each emulator's host-mapped port and exposes new "container-emulator-host"/"container-host-override" config properties pointing at host.testcontainers.internal:<port>.