### PR TITLE
Avoid returning raw FirebaseOptions from REST test resource

### DIFF
--- a/integration-tests/firebase-admin/src/main/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAppResource.java
+++ b/integration-tests/firebase-admin/src/main/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAppResource.java
@@ -21,24 +21,31 @@ public class FirebaseAppResource {
     @GET
     @Path("/options")
     @Produces(MediaType.APPLICATION_JSON)
-    public FirebaseOptions getOptions() {
-        return firebaseApp.getOptions();
+    public FirebaseOptionsDto getOptions() {
+        return toDto(firebaseApp.getOptions());
     }
 
     @GET
     @Authenticated
     @Path("/secret-options")
     @Produces(MediaType.APPLICATION_JSON)
-    public FirebaseOptions getSecretOptions() {
-        return firebaseApp.getOptions();
+    public FirebaseOptionsDto getSecretOptions() {
+        return toDto(firebaseApp.getOptions());
     }
 
     @GET
     @RolesAllowed({ "admin" })
     @Path("/admin-options")
     @Produces(MediaType.APPLICATION_JSON)
-    public FirebaseOptions getAdminOptions() {
-        return firebaseApp.getOptions();
+    public FirebaseOptionsDto getAdminOptions() {
+        return toDto(firebaseApp.getOptions());
+    }
+
+    private static FirebaseOptionsDto toDto(FirebaseOptions options) {
+        return new FirebaseOptionsDto(options.getProjectId());
+    }
+
+    public record FirebaseOptionsDto(String projectId) {
     }
 
 }


### PR DESCRIPTION
Quarkus 3.37 changed how RESTEasy Reactive's Jackson integration generates serializers for response types: instead of invoking getters reflectively, it now calls them directly via generated bytecode. FirebaseOptions has a package-private getFirestoreOptions() getter, which RESTEasy Reactive's serializer can no longer access once the resource returns the raw SDK type, causing an IllegalAccessError at runtime.

FirebaseAppResource only ever needs to expose the project id for its tests, so return a small FirebaseOptionsDto(projectId) instead of the full FirebaseOptions object. This avoids the access error and stops leaking the whole SDK options object (including credentials) over HTTP.

Fixes failing build on #1056