### PR TITLE
Fixed the way pubsub config values are passed to the recorder

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub.adoc
@@ -133,69 +133,6 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience[`+++quarkus.google.cloud.pubsub.push.audience+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.google.cloud.pubsub.push.audience+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Audiences to accept for pubsub push messages. This can be set as a comma-separated list for multiple audiences. If the audience is not configured, the `aud` claim in the Pub sub JWT will be ignored
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token[`+++quarkus.google.cloud.pubsub.push.verification-token+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.google.cloud.pubsub.push.verification-token+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-In case this is set, a query-parameter called "token" is expected to be present in the request with the same value as this configuration option. Calls without this token will be denied. If this property is not set the token will be ignored.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email[`+++quarkus.google.cloud.pubsub.push.service-account-email+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.google.cloud.pubsub.push.service-account-email+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Email adddress of the service account used to send the pub-sub messages. The JWT used for authentication will contain this email address when Google PubSub calls the push-endpoint.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
 a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-emulator-host]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-emulator-host[`+++quarkus.google.cloud.pubsub.emulator-host+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.google.cloud.pubsub.emulator-host+++[]
@@ -282,6 +219,69 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++5+++`
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience[`+++quarkus.google.cloud.pubsub.push.audience+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.audience+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Audiences to accept for pubsub push messages. This can be set as a comma-separated list for multiple audiences. If the audience is not configured, the `aud` claim in the Pub sub JWT will be ignored
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token[`+++quarkus.google.cloud.pubsub.push.verification-token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.verification-token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+In case this is set, a query-parameter called "token" is expected to be present in the request with the same value as this configuration option. Calls without this token will be denied. If this property is not set the token will be ignored.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email[`+++quarkus.google.cloud.pubsub.push.service-account-email+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.service-account-email+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Email address of the service account used to send the pub-sub messages. The JWT used for authentication will contain this email address when Google PubSub calls the push-endpoint.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub_quarkus.google.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub_quarkus.google.adoc
@@ -133,69 +133,6 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience[`+++quarkus.google.cloud.pubsub.push.audience+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.google.cloud.pubsub.push.audience+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Audiences to accept for pubsub push messages. This can be set as a comma-separated list for multiple audiences. If the audience is not configured, the `aud` claim in the Pub sub JWT will be ignored
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token[`+++quarkus.google.cloud.pubsub.push.verification-token+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.google.cloud.pubsub.push.verification-token+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-In case this is set, a query-parameter called "token" is expected to be present in the request with the same value as this configuration option. Calls without this token will be denied. If this property is not set the token will be ignored.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
-a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email[`+++quarkus.google.cloud.pubsub.push.service-account-email+++`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.google.cloud.pubsub.push.service-account-email+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Email adddress of the service account used to send the pub-sub messages. The JWT used for authentication will contain this email address when Google PubSub calls the push-endpoint.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++`
-endif::add-copy-button-to-env-var[]
---
-|string
-|
-
 a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-emulator-host]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-emulator-host[`+++quarkus.google.cloud.pubsub.emulator-host+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.google.cloud.pubsub.emulator-host+++[]
@@ -282,6 +219,69 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++5+++`
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-audience[`+++quarkus.google.cloud.pubsub.push.audience+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.audience+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Audiences to accept for pubsub push messages. This can be set as a comma-separated list for multiple audiences. If the audience is not configured, the `aud` claim in the Pub sub JWT will be ignored
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_AUDIENCE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-verification-token[`+++quarkus.google.cloud.pubsub.push.verification-token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.verification-token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+In case this is set, a query-parameter called "token" is expected to be present in the request with the same value as this configuration option. Calls without this token will be denied. If this property is not set the token will be ignored.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_VERIFICATION_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-service-account-email[`+++quarkus.google.cloud.pubsub.push.service-account-email+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.service-account-email+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Email address of the service account used to send the pub-sub messages. The JWT used for authentication will contain this email address when Google PubSub calls the push-endpoint.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
 
 |===
 

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -17,6 +17,13 @@ quarkus.google.cloud.storage.host-override=http://localhost:8089
 %push.quarkus.google.cloud.pubsub.push.verification-token=testtoken
 %push.quarkus.google.cloud.pubsub.push.service-account-email=testme@google.com
 
+# Profile for testing that service-account-email resolves from a runtime env var (not baked in at build time).
+# service-account-email is deliberately absent here; it is supplied only via QuarkusTestProfile.getConfigOverrides().
+%push-runtime-config.quarkus.google.cloud.pubsub.push.enabled=true
+%push-runtime-config.quarkus.google.cloud.pubsub.push.audience=test-demo-audience
+%push-runtime-config.quarkus.google.cloud.pubsub.push.endpoint-path=/pubsub-push-receiver
+%push-runtime-config.quarkus.google.cloud.pubsub.push.verification-token=testtoken
+
 # Disable authentication for Bigtable on tests
 bigtable.authenticated=false
 

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushRuntimeConfigTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushRuntimeConfigTest.java
@@ -1,0 +1,137 @@
+package io.quarkiverse.googlecloudservices.it;
+
+import static io.restassured.RestAssured.given;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Priority;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.json.webtoken.JsonWebSignature;
+
+import io.quarkiverse.googlecloudservices.pubsub.push.TokenVerifier;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.http.ContentType;
+
+/**
+ * Verifies that quarkus.google.cloud.pubsub.push.service-account-email resolves correctly
+ * when the value is supplied only at runtime (e.g. via an environment variable), and is
+ * absent from application.properties at build time.
+ *
+ * This is a regression test for the BUILD_AND_RUN_TIME_FIXED → RUN_TIME config migration:
+ * with the old phase, the value was baked in at augmentation and a deploy-time env var
+ * was silently ignored; with RUN_TIME it is always read from the live config system.
+ */
+@QuarkusTest
+@TestProfile(PubSubPushRuntimeConfigTest.Profile.class)
+public class PubSubPushRuntimeConfigTest {
+
+    @ConfigProperty(name = "quarkus.google.cloud.project-id")
+    String projectId;
+
+    public static final class Profile implements QuarkusTestProfile {
+
+        @Override
+        public String getConfigProfile() {
+            return "push-runtime-config";
+        }
+
+        /**
+         * Supplies service-account-email at "runtime" only — not present in application.properties.
+         * This simulates an environment variable (e.g. QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_SERVICE_ACCOUNT_EMAIL)
+         * that is injected at deploy time but not available during the build.
+         */
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("quarkus.google.cloud.pubsub.push.service-account-email", "runtime@google.com");
+        }
+
+        @Override
+        public Set<Class<?>> getEnabledAlternatives() {
+            return Set.of(MockTokenVerifier.class);
+        }
+    }
+
+    @Alternative
+    @ApplicationScoped
+    @Priority(1)
+    public static final class MockTokenVerifier implements TokenVerifier {
+
+        @Override
+        public GoogleIdToken verify(String token) {
+            var header = new JsonWebSignature.Header();
+            var payload = new GoogleIdToken.Payload();
+
+            if ("valid-token".equals(token)) {
+                // email matches the value supplied via getConfigOverrides() — should be accepted
+                payload.setEmailVerified(true);
+                payload.setEmail("runtime@google.com");
+            } else if ("wrong-email".equals(token)) {
+                // email does not match — should be rejected even if token is otherwise valid
+                payload.setEmailVerified(true);
+                payload.setEmail("other@google.com");
+            }
+            // any other token → empty payload → missing email → rejected
+
+            return new GoogleIdToken(header, payload, new byte[0], new byte[0]);
+        }
+    }
+
+    @Test
+    public void testRuntimeServiceAccountEmailIsAccepted() {
+        // The service-account-email "runtime@google.com" was supplied only via getConfigOverrides(),
+        // not in application.properties. If the config were BUILD_AND_RUN_TIME_FIXED this would fail
+        // because the build-time value would be empty and the filter would throw on orElseThrow().
+        given()
+                .body(createMessage("hello"))
+                .header("Authorization", "Bearer valid-token")
+                .contentType(ContentType.JSON)
+                .when().post("/pubsub-push-receiver?token=testtoken")
+                .then()
+                .statusCode(200);
+    }
+
+    @Test
+    public void testWrongServiceAccountEmailIsRejected() {
+        given()
+                .body(createMessage("hello"))
+                .header("Authorization", "Bearer wrong-email")
+                .contentType(ContentType.JSON)
+                .when().post("/pubsub-push-receiver?token=testtoken")
+                .then()
+                .statusCode(401);
+    }
+
+    @Test
+    public void testMissingAuthHeaderIsRejected() {
+        given()
+                .body(createMessage("hello"))
+                .contentType(ContentType.JSON)
+                .when().post("/pubsub-push-receiver?token=testtoken")
+                .then()
+                .statusCode(401);
+    }
+
+    private String createMessage(String message) {
+        var data = Base64.getEncoder().encodeToString(message.getBytes(StandardCharsets.UTF_8));
+        return "{\n" +
+                "\"subscription\": \"projects/" + projectId + "/subscriptions/test-push-subscription\",\n" +
+                "\"publishTime\" : \"2021-02-26T19:13:55.749Z\",\n" +
+                "\"message\": {\n" +
+                "\"data\": \"" + data + "\",\n" +
+                "\"messageId\": \"1\"\n" +
+                "}\n" +
+                "}\n";
+    }
+}

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployment/PubSubBuildSteps.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployment/PubSubBuildSteps.java
@@ -53,7 +53,7 @@ public class PubSubBuildSteps {
                     .build());
 
             additionalFilters.produce(new FilterBuildItem(
-                    recorder.authHandlerInstance(recorder.authenticationHandler(endpoint, config)),
+                    recorder.authHandlerInstance(recorder.authenticationHandler(endpoint)),
                     999));
         });
 

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployment/PubSubDevServiceProcessor.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployment/PubSubDevServiceProcessor.java
@@ -5,10 +5,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jboss.logging.Logger;
-import org.testcontainers.containers.PubSubEmulatorContainer;
+import org.testcontainers.gcloud.PubSubEmulatorContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import io.quarkus.deployment.IsNormal;
+import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.builditem.*;
@@ -23,7 +23,7 @@ import io.quarkus.devservices.common.ConfigureUtil;
  * <p>
  * The processor starts the Pub/Sub service in case it's not running.
  */
-@BuildSteps(onlyIfNot = IsNormal.class, onlyIf = DevServicesConfig.Enabled.class)
+@BuildSteps(onlyIfNot = IsProduction.class, onlyIf = DevServicesConfig.Enabled.class)
 public class PubSubDevServiceProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(PubSubDevServiceProcessor.class.getName());

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushBuildTimeConfig.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushBuildTimeConfig.java
@@ -21,23 +21,4 @@ public interface PubSubPushBuildTimeConfig {
      * The endpoint path for the pubsub push calls.
      */
     Optional<String> endpointPath();
-
-    /**
-     * Audiences to accept for pubsub push messages. This can be set as a comma-separated list for multiple
-     * audiences. If the audience is not configured, the <code>aud</code> claim in the Pub sub JWT will be ignored
-     */
-    Optional<String> audience();
-
-    /**
-     * In case this is set, a query-parameter called "token" is expected to be present in the request with the same
-     * value as this configuration option. Calls without this token will be denied. If this property is not set
-     * the token will be ignored.
-     */
-    Optional<String> verificationToken();
-
-    /**
-     * Email adddress of the service account used to send the pub-sub messages. The JWT used for authentication will
-     * contain this email address when Google PubSub calls the push-endpoint.
-     */
-    Optional<String> serviceAccountEmail();
 }

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRecorder.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRecorder.java
@@ -5,6 +5,7 @@ import java.util.function.Consumer;
 import jakarta.enterprise.inject.spi.CDI;
 
 import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.RecordableConstructor;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
@@ -19,6 +20,13 @@ import io.vertx.ext.web.handler.BodyHandler;
 @Recorder
 public class PubSubPushRecorder {
 
+    private RuntimeValue<PubSubPushRuntimeConfig> config;
+
+    @RecordableConstructor
+    public PubSubPushRecorder(RuntimeValue<PubSubPushRuntimeConfig> config) {
+        this.config = config;
+    }
+
     public Consumer<Route> routeFunction() {
         var endpointHandler = CDI.current().select(PubSubPushEndpointHandler.class).get();
 
@@ -28,14 +36,13 @@ public class PubSubPushRecorder {
                 .handler(endpointHandler);
     }
 
-    public RuntimeValue<GooglePubSubAuthenticationHandler> authenticationHandler(String endpoint,
-            PubSubPushBuildTimeConfig config) {
+    public RuntimeValue<GooglePubSubAuthenticationHandler> authenticationHandler(String endpoint) {
         var tokenVerifier = CDI.current().select(TokenVerifier.class).get();
 
         return new RuntimeValue<>(new GooglePubSubAuthenticationHandler(
                 endpoint,
-                config.verificationToken(),
-                config.serviceAccountEmail().orElseThrow(),
+                config.getValue().verificationToken(),
+                config.getValue().serviceAccountEmail().orElseThrow(),
                 tokenVerifier));
     }
 

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRuntimeConfig.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRuntimeConfig.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.googlecloudservices.pubsub.push;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigMapping(prefix = "quarkus.google.cloud.pubsub.push")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface PubSubPushRuntimeConfig {
+
+    /**
+     * Audiences to accept for pubsub push messages. This can be set as a comma-separated list for multiple
+     * audiences. If the audience is not configured, the <code>aud</code> claim in the Pub sub JWT will be ignored
+     */
+    Optional<String> audience();
+
+    /**
+     * In case this is set, a query-parameter called "token" is expected to be present in the request with the same
+     * value as this configuration option. Calls without this token will be denied. If this property is not set
+     * the token will be ignored.
+     */
+    Optional<String> verificationToken();
+
+    /**
+     * Email address of the service account used to send the pub-sub messages. The JWT used for authentication will
+     * contain this email address when Google PubSub calls the push-endpoint.
+     */
+    Optional<String> serviceAccountEmail();
+}


### PR DESCRIPTION
Previous, this setup works (although it was not correct). Since Quarkus 3.7, the core has become more strict and runtime values are no longer resolved in a recorder when a Build-time config is used. In the new setup, the audience, etc values are correctly read at runtime instead of resolved at buildtime. As the audience is most often configured via environment parameters (from the Pub Sub config on GCP) this setup is needed to get Pub sub working again.