### PR TITLE
Add support for Vite

### DIFF
--- a/docs/modules/ROOT/pages/firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/firebase-devservices.adoc
@@ -176,6 +176,54 @@ A simple setup would be
 
 Note that a redirect from the hosting emulator to the Quarkus instance is currently not supported by the emulator.
 
+=== Web framework dev servers
+
+When the Hosting emulator is enabled, the DevService inspects the configured hosting directory to detect whether it
+contains a supported frontend framework project, using the same detection signals `firebase-tools` itself uses. If a
+supported framework is detected, the generated Docker image is adjusted so the framework's own dev server (including
+its hot-reload/HMR client) can be used from inside the container. What exactly is adjusted, and what you may need to
+configure in your own project, is detailed per framework below.
+
+Currently supported frameworks:
+
+* Vite
+
+==== Vite
+
+`firebase-tools` spawns the project's own `vite` binary directly, without any CLI flags, and serves pages through
+the Hosting emulator using a plain HTTP request/response proxy that does not forward WebSocket upgrades. To make
+hot-reload work from inside this DevService, the following adjustments are applied to the Docker image:
+
+* File-change events on the bind-mounted host directory are not reliably delivered as `inotify` events into the
+  container, so `CHOKIDAR_USEPOLLING` is enabled to fall back to filesystem polling, which `chokidar` (Vite's file
+  watcher) honors.
+* Vite's dev server port (`5173`) is published on the Docker host under the same port number, since Vite's HMR
+  client reconnects directly to that port rather than through the Hosting emulator's own proxy.
+
+On top of that, two things need to be configured explicitly in your own `vite.config.js`/`vite.config.ts` for
+hot-reload to actually work:
+
+[source,js]
+----
+export default defineConfig({
+  server: {
+    // Vite defaults to binding only the loopback interface, which is unreachable from the Docker
+    // host even though the dev server port is published.
+    host: true,
+    hmr: {
+      // Must match Vite's default dev server port (5173). Without this, the HMR client falls back
+      // to the page's own port (the Hosting emulator's port), which cannot proxy WebSocket
+      // connections and will never connect.
+      clientPort: 5173,
+    },
+  },
+})
+----
+
+Without these settings, the page loads and the browser console shows the dev server connecting (e.g. "[vite]
+connecting..."), but file changes never trigger a reload, since the HMR WebSocket never actually reaches the Vite
+dev server.
+
 === Auth emulator
 
 You can use the features provided by Mircoprofile JWT (e.g. injecting a `@Claim` value) by including the smallrye-jwt

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
@@ -1001,7 +1001,40 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
         }
     }
 
+    /**
+     * Interface to implement support for specific Web frameworks, to match the support Firebase has for these.
+     */
+    interface WebFramework {
+
+        /**
+         * Name of the framework.
+         */
+        String name();
+
+        /**
+         * Returns true if the usage of the framework was detected.
+         */
+        boolean detected();
+
+        /**
+         * Apply the needed changes to the docker file
+         *
+         * @param builder The docker file builder
+         */
+        void apply(DockerfileBuilder builder);
+
+        /**
+         * Container-internal ports that need to be published to the Docker host directly, in addition to the
+         * configured emulators. Frameworks whose dev server is reached directly by the browser (e.g. for
+         * hot-reload websocket connections that bypass the Hosting emulator's proxy) should override this.
+         */
+        default Set<Integer> additionalExposedPorts() {
+            return Set.of();
+        }
+    }
+
     private final Map<Emulator, ExposedPort> services;
+    private final Set<Integer> additionalExposedPorts;
     private final boolean followStdOut;
     private final boolean followStdErr;
     private final Consumer<FirebaseEmulatorContainer> afterStart;
@@ -1023,9 +1056,14 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
      * @param emulatorConfig The generic configuration of the firebase emulators
      */
     public FirebaseEmulatorContainer(EmulatorConfig emulatorConfig) {
-        super(new FirebaseDockerBuilder(emulatorConfig).build());
+        this(new FirebaseDockerBuilder(emulatorConfig), emulatorConfig);
+    }
+
+    private FirebaseEmulatorContainer(FirebaseDockerBuilder dockerBuilder, EmulatorConfig emulatorConfig) {
+        super(dockerBuilder.build());
 
         this.services = emulatorConfig.firebaseConfig().services;
+        this.additionalExposedPorts = dockerBuilder.additionalExposedPorts();
         this.followStdOut = emulatorConfig.dockerConfig().followStdOut();
         this.followStdErr = emulatorConfig.dockerConfig().followStdErr();
         this.afterStart = emulatorConfig.dockerConfig().afterStart();
@@ -1038,17 +1076,12 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
         });
 
         if (this.services.containsKey(Emulator.FIREBASE_HOSTING)) {
-            var hostingPath = emulatorConfig
-                    .firebaseConfig()
-                    .hostingConfig()
-                    .hostingContentDir()
-                    .map(Path::toString)
-                    .orElse(new File(FirebaseJsonBuilder.FIREBASE_HOSTING_SUBPATH).getAbsolutePath());
+            var hostingPath = hostHostingPath(emulatorConfig);
 
             LOGGER.debug("Mounting {} to the container hosting path", hostingPath);
 
             // Mount volume for static hosting content
-            this.withFileSystemBind(hostingPath, containerHostingPath(emulatorConfig), BindMode.READ_WRITE);
+            this.withFileSystemBind(hostingPath.toString(), containerHostingPath(emulatorConfig), BindMode.READ_WRITE);
         }
 
         if (this.services.containsKey(Emulator.CLOUD_FUNCTIONS)) {
@@ -1064,6 +1097,20 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             // Mount volume for functions
             this.withFileSystemBind(functionsPath, containerFunctionsPath(emulatorConfig), BindMode.READ_WRITE);
         }
+    }
+
+    /**
+     * The local (host machine) directory holding the hosting content, which gets bind-mounted into the
+     * container. This is where {@link WebFramework} detection looks for framework-specific files, since the
+     * container's own filesystem doesn't have the hosting content available until the volume is mounted at
+     * container startup.
+     */
+    private static Path hostHostingPath(EmulatorConfig emulatorConfig) {
+        return emulatorConfig
+                .firebaseConfig()
+                .hostingConfig()
+                .hostingContentDir()
+                .orElseGet(() -> new File(FirebaseJsonBuilder.FIREBASE_HOSTING_SUBPATH).getAbsoluteFile().toPath());
     }
 
     static String containerHostingPath(EmulatorConfig emulatorConfig) {
@@ -1119,6 +1166,9 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
 
     private static class FirebaseDockerBuilder {
 
+        private final WebFramework[] webFrameworks;
+        private final Set<Integer> additionalExposedPorts = new LinkedHashSet<>();
+
         private final ImageFromDockerfile result;
 
         private final EmulatorConfig emulatorConfig;
@@ -1131,6 +1181,9 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
         public FirebaseDockerBuilder(EmulatorConfig emulatorConfig) {
             this.devServices = emulatorConfig.firebaseConfig().services;
             this.emulatorConfig = emulatorConfig;
+            this.webFrameworks = isEmulatorEnabled(Emulator.FIREBASE_HOSTING)
+                    ? new WebFramework[] { new ViteWebFramework(hostHostingPath(emulatorConfig)) }
+                    : new WebFramework[0];
 
             LOGGER.debug("Loaded emulator config {}", this.emulatorConfig);
 
@@ -1164,6 +1217,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             this.includeFirestoreFiles();
             this.includeStorageFiles();
             this.includeAdditionalEnvironmentVariables();
+            this.checkForSupportedWebFrameworks();
             this.runExecutable();
 
             return result;
@@ -1438,6 +1492,21 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             });
         }
 
+        private void checkForSupportedWebFrameworks() {
+            LOGGER.info("Checking for additional web frameworks which may be enabled");
+            Arrays.stream(webFrameworks).forEach(framework -> {
+                if (framework.detected()) {
+                    LOGGER.info("Detected web framework {}. Applying configuration", framework.name());
+                    framework.apply(dockerBuilder);
+                    additionalExposedPorts.addAll(framework.additionalExposedPorts());
+                }
+            });
+        }
+
+        Set<Integer> additionalExposedPorts() {
+            return additionalExposedPorts;
+        }
+
         private void runExecutable() {
             List<String> arguments = new ArrayList<>();
 
@@ -1579,6 +1648,12 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                         addExposedPort(emulator.internalPort);
                     }
                 });
+
+        // Web framework dev servers (e.g. Vite) are reached directly by the browser for hot-reload websocket
+        // connections, bypassing the Hosting emulator's proxy, so they need a host-reachable port regardless
+        // of shared-network mode. Published on the same port number inside and outside the container, since
+        // that's the port the dev server's client-side code will try to reconnect to.
+        additionalExposedPorts.forEach(port -> addFixedExposedPort(port, port));
 
         waitingFor(Wait.forLogMessage(".*✔  All emulators ready! It is now safe to connect your app.*", 1));
     }

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/ViteWebFramework.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/ViteWebFramework.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.googlecloudservices.firebase.deployment.testcontainers;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.images.builder.dockerfile.DockerfileBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Detects projects using <a href="https://vite.dev">Vite</a> for the Firebase Hosting content, using the same
+ * detection signals as firebase-tools itself (see {@code discover()} in
+ * <a href="https://github.com/firebase/firebase-tools/blob/master/src/frameworks/vite/index.ts">
+ * src/frameworks/vite/index.ts</a>): a {@code package.json} combined with either a {@code vite.config.js}/
+ * {@code vite.config.ts} file or a {@code vite} dependency.
+ * <p>
+ * Running the Vite dev server through the Firebase Hosting emulator inside Docker breaks hot module reloading:
+ * the hosting directory is a bind-mounted volume, which doesn't reliably deliver inotify events into the
+ * container, so chokidar (used by Vite) never notices source changes on the host. On top of that, the dev
+ * server's own port isn't published to the host by default, and the browser's HMR client connects to it
+ * directly rather than through the Hosting emulator's proxy.
+ */
+public class ViteWebFramework implements FirebaseEmulatorContainer.WebFramework {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ViteWebFramework.class);
+
+    /**
+     * Vite's default dev server port. Firebase spawns {@code vite} without any CLI flags, so unless the
+     * project's own {@code vite.config} overrides it, this is the port the dev server ends up listening on.
+     */
+    static final int DEV_SERVER_PORT = 5173;
+
+    private final Path hostingDirectory;
+
+    public ViteWebFramework(Path hostingDirectory) {
+        this.hostingDirectory = hostingDirectory;
+    }
+
+    @Override
+    public String name() {
+        return "Vite";
+    }
+
+    @Override
+    public boolean detected() {
+        LOGGER.info("Starting detection of Vite in hosting directory {}", hostingDirectory);
+        var packageJson = hostingDirectory.resolve("package.json");
+        if (!Files.isRegularFile(packageJson)) {
+            LOGGER.info("No package.json file detected for vite support");
+            return false;
+        }
+
+        var hasConfigFile = Files.isRegularFile(hostingDirectory.resolve("vite.config.js"))
+                || Files.isRegularFile(hostingDirectory.resolve("vite.config.ts"));
+
+        if (!hasConfigFile) {
+            LOGGER.info("No Vite config file detected");
+        }
+
+        return hasConfigFile || declaresViteDependency(packageJson);
+    }
+
+    private boolean declaresViteDependency(Path packageJson) {
+        try {
+            var parsed = new ObjectMapper().readValue(packageJson.toFile(), FirebaseToolsVersionReader.PackageJson.class);
+            return parsed.getDependencies().containsKey("vite") || parsed.getDevDependencies().containsKey("vite");
+        } catch (IOException e) {
+            LOGGER.debug("Failed to read {} while detecting Vite, treating as not detected", packageJson, e);
+            return false;
+        }
+    }
+
+    @Override
+    public void apply(DockerfileBuilder builder) {
+        // Bind-mounted hosting directories don't reliably deliver filesystem change events into the
+        // container, so fall back to polling for chokidar-based watchers (used by Vite).
+        builder.env("CHOKIDAR_USEPOLLING", "true");
+
+        // Published on the same port number inside and outside the container: Vite's HMR client connects
+        // directly to "<page-host>:<dev-server-port>" rather than through the Hosting emulator's proxy, so the
+        // externally reachable port must match the one Vite itself reports.
+        builder.expose(DEV_SERVER_PORT);
+    }
+
+    @Override
+    public Set<Integer> additionalExposedPorts() {
+        return Set.of(DEV_SERVER_PORT);
+    }
+}


### PR DESCRIPTION
Vite allows hot reload of the web code, however this was blocked in the way Vite was exposed through the firebase emulator in the docker container. Logic has been added to expose vite correctly (including documentation on the needed configuration changes).

In the future, support for more web frameworks may be added (same as firebase itself supports), so a strategy/factory approach was used here.