### PR TITLE
Improve support for vite with configurable port and improve networking

### DIFF
--- a/docs/modules/ROOT/pages/firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/firebase-devservices.adoc
@@ -157,6 +157,137 @@ If emulators are configured via the configuration options, a `firebase.json` fil
 * Each of the emulators must be exposed on `0.0.0.0` as host as described https://firebase.google.com/docs/emulator-suite/use_hosting#emulators-no-local-host[here]. If this is not done, the Emulators will not be reachable from the Docker host.
 * Emulators need to be configured to use the default ports. Customizing the ports on which they run is currently not supported (this might change in a future version).
 
+== Connectivity
+
+Each emulator's address is exposed to your application through two config properties, because which one is
+actually reachable depends on where your code runs. These properties are consumed by the respective extensions
+themselves (`FirestoreProducer`, `FirebaseAdminProducer`, `StorageProducer`, `FirebaseDatabaseProducer`, ...) - you
+normally never read them directly, but it helps to know which is which when debugging connectivity issues.
+
+[.configuration-reference.searchable, cols="20,27,27,26"]
+|===
+
+h|Emulator
+h|App-facing property
+h|Companion-container property
+h|Default
+
+|Auth
+|`quarkus.google.cloud.firebase.auth.emulator-host`
+|`quarkus.google.cloud.firebase.auth.container-emulator-host`
+|random port
+
+|Emulator Suite UI
+|`quarkus.google.cloud.firebase.emulator-host`
+|`quarkus.google.cloud.firebase.container-emulator-host`
+|random port
+
+|Firebase Hosting
+|`quarkus.google.cloud.firebase.hosting.emulator-host`
+|`quarkus.google.cloud.firebase.hosting.container-emulator-host`
+|random port
+
+|Cloud Functions
+|`quarkus.google.cloud.functions.emulator-host`
+|`quarkus.google.cloud.functions.container-emulator-host`
+|random port
+
+|EventArc
+|`quarkus.google.cloud.eventarc.emulator-host`
+|`quarkus.google.cloud.eventarc.container-emulator-host`
+|random port (only settable via a custom `firebase.json`, see above - not exposed as a devservices config property)
+
+|Realtime Database
+|`quarkus.google.cloud.firebase.database.host-override`
+|`quarkus.google.cloud.firebase.database.container-host-override`
+|random port
+
+|Cloud Firestore
+|`quarkus.google.cloud.firestore.host-override`
+|`quarkus.google.cloud.firestore.container-host-override`
+|random port
+
+|Cloud Storage
+|`quarkus.google.cloud.storage.host-override`
+|`quarkus.google.cloud.storage.container-host-override`
+|random port
+
+|Pub/Sub
+|`quarkus.google.cloud.pubsub.emulator-host`
+|`quarkus.google.cloud.pubsub.container-emulator-host`
+|random port
+
+|===
+
+Every emulator listed above defaults to a randomly Docker-assigned host port; you can pin one to a specific port via
+its own `emulator-port` config property (e.g. `quarkus.google.cloud.devservices.firebase.firestore.emulator-port`).
+The Vite dev server (see below) is the one exception: it is always published on host port `5173`, with no
+configuration option.
+
+NOTE: Throughout this page, *the Docker host* refers to `getHost():getMappedPort()` (Testcontainers) - the address
+your emulator container's published ports are reachable on from outside Docker. This is usually, but not always,
+literally `localhost`: `getHost()` resolves via `DockerClientProviderStrategy.resolveDockerHostIpAddress()`, which
+returns `localhost` for a local Docker Desktop/Engine reached over a unix socket, the daemon's own host for a
+remote/TCP Docker daemon, and the Docker bridge network's gateway IP when the build itself runs inside a container
+(a common "Docker-outside-of-Docker" CI setup) - `TESTCONTAINERS_HOST_OVERRIDE` overrides all of this when set.
+
+The app-facing property (first column) resolves to the Docker host when shared-network mode is inactive, and to the
+shared-network alias whenever it *is* active - mirroring the same blanket `useSharedNetwork` check the sibling
+Google Cloud Dev Services (Firestore, PubSub, ...) already use. In practice, shared-network mode is normally only
+active because Quarkus itself requires it for a containerized `@QuarkusIntegrationTest` run, which it attaches to
+that same network automatically, so the alias resolves correctly.
+
+CAUTION: If you manually force shared-network mode on for an unrelated reason
+(`quarkus.devservices.launch-on-shared-network=true`) while your actual consumer is still a plain host-JVM process
+(`quarkus:dev`, a regular `@QuarkusTest`, a non-containerized `@QuarkusIntegrationTest`), that consumer gets the
+alias here too and won't be able to reach it.
+
+The companion-container property (second column) is populated by default, regardless of network mode. It exists for
+a container *your own test code* starts via Testcontainers in the same JVM (e.g. a Playwright browser container)
+that needs to reach the emulator - reachable via the `host.testcontainers.internal` ambassador hostname that
+`Testcontainers.exposeHostPorts()` sets up. Since this starts one extra ambassador container (shared across the
+whole JVM - harmless if something else already triggered it, but wasted if nothing ever needs it), you can turn it
+off entirely if your tests never start a companion container that needs to reach the emulator:
+
+[source,properties]
+----
+quarkus.google.cloud.devservices.firebase.emulator.expose-to-companion-containers=false
+----
+
+[cols="35,65"]
+|===
+
+h|Situation
+h|Address
+
+|Host-JVM consumer (`quarkus:dev`, `@QuarkusTest`, non-containerized `@QuarkusIntegrationTest`), shared-network inactive
+|The Docker host
+
+|Host-JVM consumer, shared-network manually forced active for an unrelated reason
+|Shared-network alias - unreachable from a host-JVM process, see the caution above
+
+|`@QuarkusIntegrationTest`, containerized (always forces shared-network mode on)
+|`<network alias>:<container port>` - attached to that network automatically by Quarkus
+
+|A companion container your test starts itself, also attached to the shared network
+|`<network alias>:<container port>` or, if `expose-to-companion-containers` is enabled (default),
+`host.testcontainers.internal:<host-mapped port>` - either works
+
+|A companion container your test starts itself, not attached to the shared network
+|`host.testcontainers.internal:<host-mapped port>`, and requires `expose-to-companion-containers` (default: enabled)
+
+|Browser, from the host machine
+|The Docker host
+
+|===
+
+IMPORTANT: The two shared-facing forms use *different* port numbers, and mixing them up will simply fail to
+connect. The network alias always addresses the emulator's *internal* container port; the
+`host.testcontainers.internal` ambassador always forwards to the *host-mapped* port published on the Docker host -
+never the internal one, since the ambassador itself runs outside the container and forwards through the Docker
+host's own published port mapping. This distinction disappears (both numbers are equal) once an emulator is pinned
+to a fixed port, or for the Vite dev server.
+
 == Details on specific Devservices
 
 The following sections provide documentation in interaction with specific emulators.
@@ -199,6 +330,8 @@ hot-reload work from inside this DevService, the following adjustments are appli
   watcher) honors.
 * Vite's dev server port (`5173`) is published on the Docker host under the same port number, since Vite's HMR
   client reconnects directly to that port rather than through the Hosting emulator's own proxy.
+* The resolved port is also set as the `VITE_HMR_PORT` environment variable inside the container, so
+  `vite.config.js`/`vite.config.ts` can read it back instead of hardcoding it.
 
 On top of that, two things need to be configured explicitly in your own `vite.config.js`/`vite.config.ts` for
 hot-reload to actually work:
@@ -211,18 +344,48 @@ export default defineConfig({
     // host even though the dev server port is published.
     host: true,
     hmr: {
-      // Must match Vite's default dev server port (5173). Without this, the HMR client falls back
-      // to the page's own port (the Hosting emulator's port), which cannot proxy WebSocket
-      // connections and will never connect.
-      clientPort: 5173,
+      // Read back the port the DevService actually published (see VITE_HMR_PORT below), falling back
+      // to Vite's own default outside the emulator (e.g. a plain `vite dev` on your machine). Without
+      // this, the HMR client falls back to the page's own port (the Hosting emulator's port), which
+      // cannot proxy WebSocket connections and will never connect.
+      clientPort: Number(process.env.VITE_HMR_PORT) || 5173,
     },
   },
 })
 ----
 
+`process.env` works here regardless of the `VITE_` prefix - that prefix only governs which variables Vite exposes
+to client-side code via `import.meta.env`; `vite.config.js` itself is a plain Node.js script and can read any
+environment variable. Reading it back this way, instead of hardcoding a number, keeps `vite.config.js` and the
+DevService in sync automatically, including if you configure a different port per profile (see below).
+
 Without these settings, the page loads and the browser console shows the dev server connecting (e.g. "[vite]
 connecting..."), but file changes never trigger a reload, since the HMR WebSocket never actually reaches the Vite
 dev server.
+
+Unlike every other emulator managed by this DevService, the Vite HMR port is published on a *fixed* Docker host
+port rather than a randomly assigned one, since the browser's HMR client needs to reach it directly at a
+predictable address. If your own `vite.config.js`/`vite.config.ts` overrides `server.port` to something other than
+Vite's default of `5173`, tell the DevService about it so it publishes the right port:
+
+[source,properties]
+----
+quarkus.google.cloud.devservices.firebase.hosting.vite.hmr-port=5174
+----
+
+It's also recommended to set `server.strictPort: true` in `vite.config`, so Vite fails fast instead of silently
+falling back to a different port if the configured one is unavailable inside the container. The DevService logs a
+best-effort warning at startup if it detects a likely mismatch or a missing `strictPort` setting, but this is a
+plain-text heuristic (not a full JS/TS parser), so it can't reliably catch every case - except when it detects
+`vite.config` reading `server.port` from `process.env.VITE_HMR_PORT`, which it recognizes as a confirmed match
+rather than an unknown case.
+
+Because this port is fixed rather than random, running two instances of the emulator at once (e.g. `quarkus:dev`
+together with continuous testing, or `quarkus:dev` alongside a separately started `mvn test`) can fail with a
+"port is already allocated" error if both try to publish the same Vite HMR port. If you need dev mode and tests to
+run side by side, configure a different `hmr-port` for the `%test` profile. If your `vite.config.js`/`vite.config.ts`
+reads `server.port` from `VITE_HMR_PORT` as shown above, that's all you need to do - the config stays in sync
+automatically. If you hardcode the port instead, you'll also need to mirror that same value there by hand.
 
 === Auth emulator
 

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceConfig.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceConfig.java
@@ -121,6 +121,16 @@ public interface FirebaseDevServiceConfig {
              */
             UI ui();
 
+            /**
+             * Whether to expose the emulator's ports to companion containers this JVM starts via Testcontainers
+             * (e.g. a Playwright browser container), reachable via the {@code host.testcontainers.internal}
+             * ambassador hostname. Starts one small extra ambassador container (shared across the whole JVM, so
+             * this doesn't add up if other Dev Services already use it). Disable this if your tests never need a
+             * companion container to reach the emulator this way.
+             */
+            @WithDefault("true")
+            boolean exposeToCompanionContainers();
+
             interface Docker {
                 /**
                  * Sets the Docker image name for the Google Cloud SDK.
@@ -260,6 +270,30 @@ public interface FirebaseDevServiceConfig {
              * Path to the hosting files.
              */
             Optional<String> hostingPath();
+
+            /**
+             * Settings specific to a <a href="https://vite.dev">Vite</a>-based hosting project. Nested under its
+             * own group (rather than flat properties on {@link HostingDevService}) so future Vite-specific settings
+             * have a natural place to live.
+             */
+            Vite vite();
+
+            interface Vite {
+                /**
+                 * The port the project's own Vite dev server is configured to listen on (the {@code server.port}
+                 * setting in {@code vite.config.js}/{@code vite.config.ts}), and therefore also the port the
+                 * browser's Vite HMR (hot module reload) client tries to reconnect on. Only relevant when the
+                 * hosting directory is detected as a Vite project. Defaults to Vite's own default of 5173, which is
+                 * what Firebase's emulator uses when it spawns the dev server without any {@code server.port}
+                 * override present.
+                 * <p>
+                 * If your {@code vite.config} customizes {@code server.port}, set this to the same value so the
+                 * emulator publishes the port the HMR client actually needs to reach. It's recommended to also set
+                 * {@code server.strictPort: true} in {@code vite.config}, so Vite fails fast instead of silently
+                 * picking a different port if this one turns out to be unavailable.
+                 */
+                Optional<Integer> hmrPort();
+            }
         }
 
         /**

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceProcessor.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceProcessor.java
@@ -271,10 +271,11 @@ public class FirebaseDevServiceProcessor {
         // Set the config for the started container
         FirebaseDevServiceProcessor.config = config;
 
-        var emulatorContainerConfig = emulatorContainerConfig(emulatorContainer, useSharedNetwork);
+        var emulatorContainerConfig = emulatorContainerConfig(emulatorContainer, useSharedNetwork,
+                config.firebase().emulator().exposeToCompanionContainers());
 
         if (LOGGER.isInfoEnabled()) {
-            var runningPorts = emulatorContainer.emulatorUrls();
+            var runningPorts = emulatorContainer.hostEmulatorUrls();
             runningPorts.forEach((e, p) -> LOGGER.info("Google Cloud Emulator " + e + " reachable on " + p));
 
             emulatorContainerConfig
@@ -290,8 +291,15 @@ public class FirebaseDevServiceProcessor {
                 emulatorContainerConfig);
     }
 
-    private Map<String, String> emulatorContainerConfig(FirebaseEmulatorContainer emulatorContainer, boolean useSharedNetwork) {
-        var emulatorProperties = new HashMap<>(emulatorContainer.emulatorEndpoints()
+    private Map<String, String> emulatorContainerConfig(FirebaseEmulatorContainer emulatorContainer,
+            boolean useSharedNetwork, boolean exposeToCompanionContainers) {
+        // App-facing properties: the Docker host by default (reachable from the host-JVM running dev mode or a
+        // plain unit test), switched to the shared-network alias when shared-network mode is active.
+        var addressSource = useSharedNetwork
+                ? emulatorContainer.containerEmulatorUrls()
+                : emulatorContainer.hostEmulatorUrls();
+
+        var emulatorProperties = new HashMap<>(addressSource
                 .entrySet()
                 .stream()
                 .filter(e -> CONFIG_PROPERTIES.containsKey(e.getKey()))
@@ -300,9 +308,8 @@ public class FirebaseDevServiceProcessor {
                                 e -> configPropertyForEmulator(e.getKey()),
                                 Map.Entry::getValue)));
 
-        // In case either the pubsub or cloud firestore is running and we use shared network mode, we force the usage
-        // of emulator credentials, as the default automatic detection won't work (because the hostname is set to the
-        // shared network host instead of localhost).
+        // Once host-override no longer contains "localhost", the automatic emulator-credentials detection (e.g.
+        // FirestoreProducer#automaticEmulatorCredentials) won't kick in, so force it explicitly.
         if (useSharedNetwork) {
             if (emulatorProperties.containsKey(CONFIG_PROPERTIES.get(FirebaseEmulatorContainer.Emulator.PUB_SUB))) {
                 emulatorProperties.put("quarkus.google.cloud.pubsub.use-emulator-credentials", "true");
@@ -311,9 +318,14 @@ public class FirebaseDevServiceProcessor {
             if (emulatorProperties.containsKey(CONFIG_PROPERTIES.get(FirebaseEmulatorContainer.Emulator.CLOUD_FIRESTORE))) {
                 emulatorProperties.put("quarkus.google.cloud.firestore.use-emulator-credentials", "true");
             }
+        }
 
-            // Expose the emulator's host-mapped ports to any container started by Testcontainers in this JVM
-            // (e.g. the Playwright browser container), reachable via the "host.testcontainers.internal" ambassador.
+        // Expose the emulator's host-mapped ports to any container started by Testcontainers in this JVM (e.g. a
+        // Playwright browser container), reachable via the "host.testcontainers.internal" ambassador. This works
+        // regardless of shared-network mode - Testcontainers.exposeHostPorts() is independent of it - so it's
+        // available whenever the user hasn't opted out, not just when shared-network happens to be on for some
+        // unrelated reason.
+        if (exposeToCompanionContainers) {
             var configuredEmulators = emulatorContainer.hostEmulatorUrls().keySet();
             configuredEmulators
                     .forEach(emulator -> Testcontainers.exposeHostPorts(emulatorContainer.hostMappedPort(emulator)));

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilder.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilder.java
@@ -144,6 +144,12 @@ public class FirebaseEmulatorConfigBuilder {
                 .ifPresent(firebaseConfigBuilder::withHostingPath);
 
         config.firebase()
+                .hosting()
+                .vite()
+                .hmrPort()
+                .ifPresent(firebaseConfigBuilder::withViteHmrPort);
+
+        config.firebase()
                 .firestore()
                 .indexesFile()
                 .map(FirebaseEmulatorConfigBuilder::asPath)

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/CustomFirebaseConfigReader.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/CustomFirebaseConfigReader.java
@@ -167,7 +167,8 @@ class CustomFirebaseConfigReader {
             LOGGER.debug("Hosting configured with public directory {}", publicDir);
 
             return new FirebaseEmulatorContainer.HostingConfig(
-                    publicDir);
+                    publicDir,
+                    Optional.empty());
         } else {
             return FirebaseEmulatorContainer.HostingConfig.DEFAULT;
         }

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
@@ -255,11 +255,15 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
      * Firebase hosting configuration
      *
      * @param hostingContentDir The path to the directory containing the hosting content
+     * @param viteHmrPort The port the project's own vite.config.js configures the Vite dev server (and therefore
+     *        its HMR client) to use, or empty to use Vite's default (see {@link ViteWebFramework#DEFAULT_HMR_PORT})
      */
     public record HostingConfig(
-            Optional<Path> hostingContentDir) {
+            Optional<Path> hostingContentDir,
+            Optional<Integer> viteHmrPort) {
 
         public static final HostingConfig DEFAULT = new HostingConfig(
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -853,7 +857,23 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
              */
             public FirebaseConfigBuilder withHostingPath(Path hostingContentDir) {
                 this.hostingConfig = new HostingConfig(
-                        Optional.of(hostingContentDir));
+                        Optional.of(hostingContentDir),
+                        this.hostingConfig.viteHmrPort());
+                return this;
+            }
+
+            /**
+             * Configure the port the project's own vite.config.js configures the Vite dev server (and therefore
+             * its HMR client) to use. Only relevant if the hosting directory is detected as a Vite project;
+             * defaults to Vite's own default (see {@link ViteWebFramework#DEFAULT_HMR_PORT}) if not set.
+             *
+             * @param viteHmrPort The Vite HMR port
+             * @return The builder
+             */
+            public FirebaseConfigBuilder withViteHmrPort(int viteHmrPort) {
+                this.hostingConfig = new HostingConfig(
+                        this.hostingConfig.hostingContentDir(),
+                        Optional.of(viteHmrPort));
                 return this;
             }
 
@@ -1035,6 +1055,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
 
     private final Map<Emulator, ExposedPort> services;
     private final Set<Integer> additionalExposedPorts;
+    private final Optional<Integer> viteHmrPort;
     private final boolean followStdOut;
     private final boolean followStdErr;
     private final Consumer<FirebaseEmulatorContainer> afterStart;
@@ -1064,6 +1085,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
 
         this.services = emulatorConfig.firebaseConfig().services;
         this.additionalExposedPorts = dockerBuilder.additionalExposedPorts();
+        this.viteHmrPort = dockerBuilder.viteHmrPort();
         this.followStdOut = emulatorConfig.dockerConfig().followStdOut();
         this.followStdErr = emulatorConfig.dockerConfig().followStdErr();
         this.afterStart = emulatorConfig.dockerConfig().afterStart();
@@ -1168,6 +1190,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
 
         private final WebFramework[] webFrameworks;
         private final Set<Integer> additionalExposedPorts = new LinkedHashSet<>();
+        private Integer detectedViteHmrPort;
 
         private final ImageFromDockerfile result;
 
@@ -1182,7 +1205,10 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             this.devServices = emulatorConfig.firebaseConfig().services;
             this.emulatorConfig = emulatorConfig;
             this.webFrameworks = isEmulatorEnabled(Emulator.FIREBASE_HOSTING)
-                    ? new WebFramework[] { new ViteWebFramework(hostHostingPath(emulatorConfig)) }
+                    ? new WebFramework[] { new ViteWebFramework(
+                            hostHostingPath(emulatorConfig),
+                            emulatorConfig.firebaseConfig().hostingConfig().viteHmrPort()
+                                    .orElse(ViteWebFramework.DEFAULT_HMR_PORT)) }
                     : new WebFramework[0];
 
             LOGGER.debug("Loaded emulator config {}", this.emulatorConfig);
@@ -1499,12 +1525,20 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
                     LOGGER.info("Detected web framework {}. Applying configuration", framework.name());
                     framework.apply(dockerBuilder);
                     additionalExposedPorts.addAll(framework.additionalExposedPorts());
+
+                    if (framework instanceof ViteWebFramework vite) {
+                        detectedViteHmrPort = vite.hmrPort();
+                    }
                 }
             });
         }
 
         Set<Integer> additionalExposedPorts() {
             return additionalExposedPorts;
+        }
+
+        Optional<Integer> viteHmrPort() {
+            return Optional.ofNullable(detectedViteHmrPort);
         }
 
         private void runExecutable() {
@@ -1663,23 +1697,12 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
     }
 
     /**
-     * Get the various endpoints for the emulators, as reachable from the JVM running the Quarkus application
-     * (i.e. {@code localhost:<mappedPort>}, even when the container is also attached to a shared network).
-     * The map values are in the form of a string "host:port".
-     *
-     * @return The emulator endpoints
-     */
-    public Map<Emulator, String> emulatorEndpoints() {
-        return hostEmulatorUrls();
-    }
-
-    /**
      * Return the TCP port an emulator is listening on.
      *
      * @param emulator The emulator
      * @return The TCP Port
      */
-    public Integer emulatorPort(Emulator emulator) {
+    public Integer containerEmulatorPort(Emulator emulator) {
         if (useSharedNetwork && !services.get(emulator).isFixed()) {
             return emulator.internalPort;
         }
@@ -1706,8 +1729,8 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
      * @param emulator The emulator
      * @return The url
      */
-    public String emulatorUrl(Emulator emulator) {
-        return this.hostName + ":" + emulatorPort(emulator);
+    public String containerEmulatorUrl(Emulator emulator) {
+        return withHttpPrefixIfNeeded(emulator, this.hostName + ":" + containerEmulatorPort(emulator));
     }
 
     /**
@@ -1729,19 +1752,21 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
      * {@code host.testcontainers.internal} ambassador) should go through this helper to stay consistent.
      *
      * @param emulator The emulator the endpoint is for
-     * @param hostPort The {@code host:port} pair to prefix
-     * @return {@code hostPort}, prefixed with {@code http://} if the emulator needs it
+     * @param authority The {@code host:port} pair to prefix
+     * @return {@code authority}, prefixed with {@code http://} if the emulator needs it
      */
-    public static String withHttpPrefixIfNeeded(Emulator emulator, String hostPort) {
+    public static String withHttpPrefixIfNeeded(Emulator emulator, String authority) {
         if (emulator == Emulator.REALTIME_DATABASE || emulator == Emulator.CLOUD_STORAGE
                 || emulator == Emulator.EMULATOR_SUITE_UI) {
-            return "http://" + hostPort;
+            return "http://" + authority;
         }
-        return hostPort;
+        return authority;
     }
 
     /**
-     * Get the host-mapped urls (see {@link #hostEmulatorUrl(Emulator)}) for all configured emulators.
+     * Get the various endpoints for the emulators, as reachable from the JVM running the Quarkus application
+     * (i.e. {@code localhost:<mappedPort>}, even when the container is also attached to a shared network).
+     * The map values are in the form of a string "host:port".
      *
      * @return A map {@link Emulator} -> {@link String} of host-reachable emulator endpoints.
      */
@@ -1758,12 +1783,23 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
      *
      * @return A map {@link Emulator} -> {@link String} indicating the host and TCP port the emulator is running on.
      */
-    public Map<Emulator, String> emulatorUrls() {
+    public Map<Emulator, String> containerEmulatorUrls() {
         return services.keySet()
                 .stream()
                 .collect(Collectors.toMap(
                         e -> e,
-                        this::emulatorUrl));
+                        this::containerEmulatorUrl));
+    }
+
+    /**
+     * The port Vite's dev server (and therefore its HMR client) is actually published on, published on the same
+     * port number inside and outside the container (see {@link ViteWebFramework}). Empty unless a Vite-based
+     * hosting project was detected.
+     *
+     * @return The resolved Vite HMR port, or empty if no Vite project was detected
+     */
+    public Optional<Integer> viteHmrPort() {
+        return viteHmrPort;
     }
 
     private void writeToStdOut(OutputFrame frame) {

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/ViteWebFramework.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/ViteWebFramework.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,15 +31,60 @@ public class ViteWebFramework implements FirebaseEmulatorContainer.WebFramework 
     private static final Logger LOGGER = LoggerFactory.getLogger(ViteWebFramework.class);
 
     /**
-     * Vite's default dev server port. Firebase spawns {@code vite} without any CLI flags, so unless the
-     * project's own {@code vite.config} overrides it, this is the port the dev server ends up listening on.
+     * Vite's default dev server port, and therefore also the default port its HMR (hot module reload) client
+     * tries to reconnect on. Firebase spawns {@code vite} without any CLI flags, so unless the project's own
+     * {@code vite.config} overrides it, this is the port the dev server ends up listening on.
      */
-    static final int DEV_SERVER_PORT = 5173;
+    static final int DEFAULT_HMR_PORT = 5173;
+
+    /**
+     * Name of the environment variable the resolved HMR port is exposed under inside the container (see
+     * {@link #apply(DockerfileBuilder)}), so {@code vite.config.js}/{@code vite.config.ts} can read it via
+     * {@code process.env.VITE_HMR_PORT} instead of hardcoding the port number. Node.js (which runs the config
+     * file, as opposed to Vite's client-side bundle) exposes the full process environment via {@code process.env},
+     * so this works regardless of the {@code VITE_} prefix - that prefix only governs which variables Vite injects
+     * into client-side code via {@code import.meta.env}, and is used here purely as a recognizable naming
+     * convention.
+     */
+    static final String HMR_PORT_ENV_VAR = "VITE_HMR_PORT";
+
+    /**
+     * Best-effort match of a {@code server: { ..., port: <number>, ... }} block in a vite.config file. Only
+     * catches the common literal-object-config case; deliberately not a full JS/TS parser.
+     */
+    private static final Pattern SERVER_PORT_PATTERN = Pattern
+            .compile("server\\s*:\\s*\\{[^}]*?\\bport\\s*:\\s*(\\d+)", Pattern.DOTALL);
+
+    /**
+     * Best-effort match of {@code server.port} being read from {@link #HMR_PORT_ENV_VAR} via {@code process.env}.
+     * When this matches, the config is guaranteed to be aligned with {@link #hmrPort}, since we set that same
+     * environment variable to that same value - no need to fall back to guessing based on a literal number.
+     */
+    private static final Pattern ENV_VAR_USAGE_PATTERN = Pattern
+            .compile("process\\.env\\." + HMR_PORT_ENV_VAR + "\\b");
+
+    /**
+     * Best-effort match of {@code strictPort: true} anywhere in a vite.config file.
+     */
+    private static final Pattern STRICT_PORT_TRUE_PATTERN = Pattern
+            .compile("strictPort\\s*:\\s*true");
 
     private final Path hostingDirectory;
+    private final int hmrPort;
 
-    public ViteWebFramework(Path hostingDirectory) {
+    public ViteWebFramework(Path hostingDirectory, int hmrPort) {
         this.hostingDirectory = hostingDirectory;
+        this.hmrPort = hmrPort;
+    }
+
+    /**
+     * The port Vite's dev server (and therefore its HMR client) is published on, resolved from
+     * {@code quarkus.google.cloud.devservices.firebase.hosting.vite.hmr-port} or {@link #DEFAULT_HMR_PORT}.
+     *
+     * @return The resolved HMR port
+     */
+    public int hmrPort() {
+        return hmrPort;
     }
 
     @Override
@@ -81,13 +128,78 @@ public class ViteWebFramework implements FirebaseEmulatorContainer.WebFramework 
         builder.env("CHOKIDAR_USEPOLLING", "true");
 
         // Published on the same port number inside and outside the container: Vite's HMR client connects
-        // directly to "<page-host>:<dev-server-port>" rather than through the Hosting emulator's proxy, so the
+        // directly to "<page-host>:<hmr-port>" rather than through the Hosting emulator's proxy, so the
         // externally reachable port must match the one Vite itself reports.
-        builder.expose(DEV_SERVER_PORT);
+        builder.expose(hmrPort);
+
+        // Let vite.config.js/vite.config.ts read the resolved port back, e.g.
+        // `server: { port: Number(process.env.VITE_HMR_PORT) }`, instead of hardcoding it - keeping the two
+        // settings in sync automatically rather than requiring the project to mirror our config value by hand.
+        builder.env(HMR_PORT_ENV_VAR, String.valueOf(hmrPort));
+
+        warnIfViteConfigLooksMismatched();
     }
 
     @Override
     public Set<Integer> additionalExposedPorts() {
-        return Set.of(DEV_SERVER_PORT);
+        return Set.of(hmrPort);
+    }
+
+    /**
+     * Best-effort sanity check of the project's {@code vite.config.js}/{@code vite.config.ts}: warns if it looks
+     * like {@code server.port} doesn't match {@link #hmrPort}, or if {@code server.strictPort} isn't set to
+     * {@code true}. This is a plain-text heuristic, not a JS/TS parser, so it can't reliably handle dynamic
+     * configs (functions, spreads, imported constants, ...); it only flags the common literal-object case and
+     * stays silent whenever it can't confidently tell - except when the config reads {@link #HMR_PORT_ENV_VAR}
+     * back via {@code process.env}, which is recognized as a confirmed match rather than an unknown case.
+     */
+    private void warnIfViteConfigLooksMismatched() {
+        var configFile = hostingDirectory.resolve("vite.config.ts");
+        if (!Files.isRegularFile(configFile)) {
+            configFile = hostingDirectory.resolve("vite.config.js");
+        }
+        if (!Files.isRegularFile(configFile)) {
+            return;
+        }
+
+        String contents;
+        try {
+            contents = Files.readString(configFile);
+        } catch (IOException e) {
+            LOGGER.debug("Failed to read {} while checking the configured Vite HMR port", configFile, e);
+            return;
+        }
+
+        if (ENV_VAR_USAGE_PATTERN.matcher(contents).find()) {
+            // Reads the port back from the same environment variable we set it to - guaranteed to be aligned,
+            // whatever the actual value is, so there's nothing left to check here.
+            LOGGER.debug("{} reads server.port from the {} environment variable; port is guaranteed to be aligned",
+                    configFile, HMR_PORT_ENV_VAR);
+        } else {
+            Matcher portMatcher = SERVER_PORT_PATTERN.matcher(contents);
+            if (portMatcher.find()) {
+                int configuredPort = Integer.parseInt(portMatcher.group(1));
+                if (configuredPort != hmrPort) {
+                    LOGGER.warn(
+                            "{} sets server.port to {}, but the Firebase Dev Service is configured to publish port "
+                                    + "{} (quarkus.google.cloud.devservices.firebase.hosting.vite.hmr-port). The "
+                                    + "browser's Vite HMR client will try to reconnect on the wrong port. Align the "
+                                    + "two values, or read server.port from the {} environment variable instead.",
+                            configFile, configuredPort, hmrPort, HMR_PORT_ENV_VAR);
+                }
+            } else {
+                LOGGER.debug("Could not detect an explicit server.port in {}; assuming it matches port {}",
+                        configFile, hmrPort);
+            }
+        }
+
+        if (!STRICT_PORT_TRUE_PATTERN.matcher(contents).find()) {
+            LOGGER.warn(
+                    "{} does not set server.strictPort: true. Without it, Vite may silently fall back to a "
+                            + "different port than the one published by the Firebase Dev Service ({}) if that "
+                            + "port turns out to be unavailable inside the container, breaking the HMR client's "
+                            + "reconnection.",
+                    configFile, hmrPort);
+        }
     }
 }

--- a/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilderTest.java
+++ b/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilderTest.java
@@ -47,12 +47,14 @@ class FirebaseEmulatorConfigBuilderTest {
                                         true,
                                         Optional.of(6000),
                                         Optional.of(6001),
-                                        Optional.of(6002))),
+                                        Optional.of(6002)),
+                                true),
                         new TestGenericDevService(true, Optional.of(6003)),
                         new TestHosting(
                                 true,
                                 Optional.of(6004),
-                                Optional.of("public")),
+                                Optional.of("public"),
+                                new TestVite(Optional.empty())),
                         new TestGenericDevService(
                                 false,
                                 Optional.of(6005)),
@@ -163,7 +165,8 @@ class FirebaseEmulatorConfigBuilderTest {
             FirebaseDevServiceConfig.Firebase.Emulator.Docker docker,
             FirebaseDevServiceConfig.Firebase.Emulator.Cli cli,
             Optional<String> customFirebaseJson,
-            UI ui) implements FirebaseDevServiceConfig.Firebase.Emulator {
+            UI ui,
+            boolean exposeToCompanionContainers) implements FirebaseDevServiceConfig.Firebase.Emulator {
     }
 
     record TestDocker(
@@ -205,7 +208,14 @@ class FirebaseEmulatorConfigBuilderTest {
     record TestHosting(
             boolean enabled,
             Optional<Integer> emulatorPort,
-            Optional<String> hostingPath) implements FirebaseDevServiceConfig.Firebase.HostingDevService {
+            Optional<String> hostingPath,
+            FirebaseDevServiceConfig.Firebase.HostingDevService.Vite vite)
+            implements
+                FirebaseDevServiceConfig.Firebase.HostingDevService {
+    }
+
+    record TestVite(
+            Optional<Integer> hmrPort) implements FirebaseDevServiceConfig.Firebase.HostingDevService.Vite {
     }
 
     record TestStorageDevService(

--- a/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainerIntegrationTest.java
+++ b/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainerIntegrationTest.java
@@ -104,7 +104,7 @@ public class FirebaseEmulatorContainerIntegrationTest {
 
     private static void customizeFirebaseOptions(FirebaseOptions.Builder builder) {
         var emulatorHost = firebaseContainer.getHost();
-        var dbPort = firebaseContainer.emulatorPort(FirebaseEmulatorContainer.Emulator.REALTIME_DATABASE);
+        var dbPort = firebaseContainer.containerEmulatorPort(FirebaseEmulatorContainer.Emulator.REALTIME_DATABASE);
 
         builder.setDatabaseUrl("http://" + emulatorHost + ":" + dbPort + "?ns=demo-test-project");
     }
@@ -163,7 +163,7 @@ public class FirebaseEmulatorContainerIntegrationTest {
     @Test
     public void testFirebaseAuthenticationEmulatorConnection() throws FirebaseAuthException {
         // Retrieve the host and port for the Authentication emulator
-        int authPort = firebaseContainer.emulatorPort(FirebaseEmulatorContainer.Emulator.AUTHENTICATION);
+        int authPort = firebaseContainer.containerEmulatorPort(FirebaseEmulatorContainer.Emulator.AUTHENTICATION);
 
         // Set the environment variable for the Firebase Authentication emulator
         FirebaseProcessEnvironment.setenv("FIREBASE_AUTH_EMULATOR_HOST", firebaseContainer.getHost() + ":" + authPort);
@@ -186,7 +186,7 @@ public class FirebaseEmulatorContainerIntegrationTest {
 
     @Test
     public void testFirestoreEmulatorConnection() throws Exception {
-        int firestorePort = firebaseContainer.emulatorPort(FirebaseEmulatorContainer.Emulator.CLOUD_FIRESTORE);
+        int firestorePort = firebaseContainer.containerEmulatorPort(FirebaseEmulatorContainer.Emulator.CLOUD_FIRESTORE);
 
         FirestoreOptions options = FirestoreOptions.newBuilder()
                 .setProjectId("demo-test-project")
@@ -236,7 +236,7 @@ public class FirebaseEmulatorContainerIntegrationTest {
     @Test
     public void testPubSubEmulatorConnection() throws Exception {
         // Retrieve the host and port for the Pub/Sub emulator
-        int pubSubPort = firebaseContainer.emulatorPort(FirebaseEmulatorContainer.Emulator.PUB_SUB);
+        int pubSubPort = firebaseContainer.containerEmulatorPort(FirebaseEmulatorContainer.Emulator.PUB_SUB);
 
         // Set up a gRPC channel to the Pub/Sub emulator
         ManagedChannel channel = ManagedChannelBuilder.forAddress(firebaseContainer.getHost(), pubSubPort)
@@ -273,7 +273,7 @@ public class FirebaseEmulatorContainerIntegrationTest {
 
     @Test
     public void testStorageEmulatorConnection() throws IOException {
-        int storagePort = firebaseContainer.emulatorPort(FirebaseEmulatorContainer.Emulator.CLOUD_STORAGE);
+        int storagePort = firebaseContainer.containerEmulatorPort(FirebaseEmulatorContainer.Emulator.CLOUD_STORAGE);
 
         Storage storage = StorageOptions.newBuilder()
                 .setHost("http://" + firebaseContainer.getHost() + ":" + storagePort)
@@ -303,7 +303,7 @@ public class FirebaseEmulatorContainerIntegrationTest {
     @Test
     public void testEmulatorUIReachable() throws Exception {
         // Get the host and port for the Emulator UI
-        int uiPort = firebaseContainer.emulatorPort(FirebaseEmulatorContainer.Emulator.EMULATOR_SUITE_UI);
+        int uiPort = firebaseContainer.containerEmulatorPort(FirebaseEmulatorContainer.Emulator.EMULATOR_SUITE_UI);
 
         // Construct the URL for the Emulator UI root (where index.html would be served)
         URL url = new URI("http://" + firebaseContainer.getHost() + ":" + uiPort + "/").toURL();
@@ -323,7 +323,7 @@ public class FirebaseEmulatorContainerIntegrationTest {
     @Test
     public void testEmulatorHub() throws Exception {
         // Get the host and port for the Emulator UI
-        int uiPort = firebaseContainer.emulatorPort(FirebaseEmulatorContainer.Emulator.EMULATOR_HUB);
+        int uiPort = firebaseContainer.containerEmulatorPort(FirebaseEmulatorContainer.Emulator.EMULATOR_HUB);
 
         // Construct the URL for the Emulator UI root (where index.html would be served)
         URL url = new URI("http://" + firebaseContainer.getHost() + ":" + uiPort + "/emulators").toURL();

--- a/integration-tests/firebase/pom.xml
+++ b/integration-tests/firebase/pom.xml
@@ -54,6 +54,13 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Used by CompanionContainerTestResource to start a minimal companion container and verify it can
+             reach the emulator via the host.testcontainers.internal ambassador -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/CompanionContainerConnectivityTest.java
+++ b/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/CompanionContainerConnectivityTest.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.googlecloudservices.it.firebase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * With the default configuration, {@code expose-to-companion-containers} is enabled, so a companion container
+ * started by the test's own code (see {@link CompanionContainerTestResource}) should be able to reach the
+ * Firebase emulator via the {@code host.testcontainers.internal} ambassador - regardless of whether shared-network
+ * mode is active for this particular test (it isn't here, since this is a plain {@code @QuarkusTest}).
+ */
+@QuarkusTest
+@QuarkusTestResource(CompanionContainerTestResource.class)
+class CompanionContainerConnectivityTest {
+
+    @ConfigProperty(name = "test.companion.container.status")
+    String companionContainerStatus;
+
+    @Test
+    void companionContainerCanReachEmulatorViaAmbassador() {
+        assertEquals("reachable", companionContainerStatus);
+    }
+}

--- a/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/CompanionContainerDisabledTest.java
+++ b/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/CompanionContainerDisabledTest.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.googlecloudservices.it.firebase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+/**
+ * With {@code expose-to-companion-containers=false}, the {@code container-host-override} dev-services property
+ * should not be published at all, so {@link CompanionContainerTestResource} never gets an ambassador URL to test.
+ */
+@QuarkusTest
+@TestProfile(NoCompanionContainerExposureProfile.class)
+@QuarkusTestResource(CompanionContainerTestResource.class)
+class CompanionContainerDisabledTest {
+
+    @ConfigProperty(name = "test.companion.container.status")
+    String companionContainerStatus;
+
+    @Test
+    void ambassadorPropertyAbsentWhenExposureDisabled() {
+        assertEquals("absent", companionContainerStatus);
+    }
+}

--- a/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/CompanionContainerTestResource.java
+++ b/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/CompanionContainerTestResource.java
@@ -1,0 +1,68 @@
+package io.quarkiverse.googlecloudservices.it.firebase;
+
+import java.util.Map;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.test.common.DevServicesContext;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+/**
+ * Starts a minimal companion container - unrelated to the application under test, comparable to e.g. a Playwright
+ * browser container a real project might start - that reaches the Firebase Realtime Database emulator via the
+ * {@code host.testcontainers.internal} ambassador exposed through the
+ * {@code quarkus.google.cloud.firebase.database.container-host-override} dev-services property. This verifies
+ * that companion-container connectivity actually works end to end, without pulling in a browser-automation
+ * dependency (e.g. Playwright) just to prove the ambassador is reachable.
+ * <p>
+ * A {@link QuarkusTestResourceLifecycleManager} can't fail a test directly, so the observed outcome is recorded as
+ * the {@code test.companion.container.status} config property ({@code reachable}, {@code unreachable}, or
+ * {@code absent} if the dev-services property itself wasn't published) - the actual assertion happens in whichever
+ * test class uses this resource.
+ */
+public class CompanionContainerTestResource implements QuarkusTestResourceLifecycleManager, DevServicesContext.ContextAware {
+
+    private static final String CONTAINER_HOST_OVERRIDE_PROPERTY = "quarkus.google.cloud.firebase.database.container-host-override";
+    private static final String STATUS_PROPERTY = "test.companion.container.status";
+
+    private DevServicesContext context;
+    private GenericContainer<?> companion;
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        this.context = context;
+    }
+
+    @Override
+    public Map<String, String> start() {
+        var ambassadorUrl = context.devServicesProperties().get(CONTAINER_HOST_OVERRIDE_PROPERTY);
+        if (ambassadorUrl == null) {
+            // expose-to-companion-containers is disabled for this test - nothing to reach.
+            return Map.of(STATUS_PROPERTY, "absent");
+        }
+
+        // Kept alive with an overridden entrypoint (curl's own default entrypoint exits immediately), so we can
+        // exec curl commands against it afterward.
+        companion = new GenericContainer<>(DockerImageName.parse("curlimages/curl:8.11.0"))
+                .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("sleep").withCmd("300"));
+        companion.start();
+
+        try {
+            var result = companion.execInContainer("curl", "-s", "-o", "/dev/null", "-w", "%{http_code}",
+                    ambassadorUrl + "/.json");
+            var httpCode = result.getStdout();
+            var reachable = httpCode != null && httpCode.matches("\\d{3}");
+            return Map.of(STATUS_PROPERTY, reachable ? "reachable" : "unreachable");
+        } catch (Exception e) {
+            return Map.of(STATUS_PROPERTY, "unreachable");
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (companion != null) {
+            companion.stop();
+        }
+    }
+}

--- a/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/NoCompanionContainerExposureProfile.java
+++ b/integration-tests/firebase/src/test/java/io/quarkiverse/googlecloudservices/it/firebase/NoCompanionContainerExposureProfile.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.googlecloudservices.it.firebase;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+/**
+ * Disables {@code expose-to-companion-containers}, for {@link CompanionContainerDisabledTest}. Also points at a
+ * dedicated {@code firebase.json} fixture with its own port range, distinct from the one the other tests in this
+ * module share (see {@code src/test/resources/firebase-companion-disabled.json}). This config change forces the
+ * shared dev-services container to be stopped and restarted for this profile; giving it different ports avoids a
+ * race between the old container releasing its ports and the new one claiming them, rather than depending on the
+ * two happening to be sequenced cleanly.
+ */
+public class NoCompanionContainerExposureProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.google.cloud.devservices.firebase.emulator.expose-to-companion-containers", "false",
+                "quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json",
+                "src/test/resources/firebase-companion-disabled.json");
+    }
+}

--- a/integration-tests/firebase/src/test/resources/firebase-companion-disabled.json
+++ b/integration-tests/firebase/src/test/resources/firebase-companion-disabled.json
@@ -1,0 +1,26 @@
+{
+  "emulators": {
+    "auth": {
+      "host": "0.0.0.0",
+      "port": 20099
+    },
+    "ui": {
+      "host": "0.0.0.0",
+      "port": 20009,
+      "enabled": true
+    },
+    "firestore": {
+      "host": "0.0.0.0",
+      "port": 20080
+    },
+    "database": {
+      "host": "0.0.0.0",
+      "port": 20000
+    },
+    "pubsub": {
+      "host": "0.0.0.0",
+      "port": 20085
+    },
+    "singleProjectMode": true
+  }
+}


### PR DESCRIPTION
The vite port is configurable now, as this was the only case where running two services side-by-side could result in errors. Also clean up the networking setup and document it, so it is more consise and the various situations are documented correctly.

Also, this fixes an issue when running in a containerized integration test and the urls for the emulators were not set correctly.