### PR TITLE
Dependabot/gc 26.86.0 fix

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -28,6 +28,7 @@
         <conscrypt.version>2.6.1</conscrypt.version><!-- mess in google-cloud-bigquery and the other google cloud lib-->
         <animal-sniffer.version>1.27</animal-sniffer.version> <!-- mess in google-cloud-storage -->
         <protobuf-version>4.35.1</protobuf-version> <!-- mess in Firebase -->
+        <opentelemetry-alpha.version>1.45.0-alpha</opentelemetry-alpha.version> <!--storage vs bigtable vs spanner -->
         <re2j-version>1.8</re2j-version>
     </properties>
 
@@ -95,6 +96,11 @@
                 <groupId>io.opencensus</groupId>
                 <artifactId>opencensus-contrib-grpc-util</artifactId>
                 <version>${opencensus.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry.contrib</groupId>
+                <artifactId>opentelemetry-gcp-resources</artifactId>
+                <version>${opentelemetry-alpha.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.threeten</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -18,7 +18,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <google-cloud-sdk.version>26.84.0</google-cloud-sdk.version>
+        <google-cloud-sdk.version>26.86.0</google-cloud-sdk.version>
         <firebase-admin-sdk.version>9.10.0</firebase-admin-sdk.version>
         <sztd-jni.version>1.5.7-12</sztd-jni.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
     <enforcer-plugin.version>3.6.3</enforcer-plugin.version>
     <assertj.version>3.27.7</assertj.version>
     <opentelemetry-alpha.version>1.64.0-alpha</opentelemetry-alpha.version>
+    <google-http-client.version>2.2.0</google-http-client.version> <!-- Quarkus defines 1.47.1, Google needs 2.20 for Storage and other project -->
   </properties>
   <scm>
     <connection>scm:git:git@github.com:quarkiverse/quarkus-google-cloud-services.git</connection>
@@ -68,6 +69,56 @@
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-opencensus-shim</artifactId>
         <version>${opentelemetry-alpha.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-android</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-apache-v2</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-apache-v5</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-appengine</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-gson</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-jackson2</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-protobuf</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-test</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client-xml</artifactId>
+        <version>${google-http-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.http-client</groupId>
+        <artifactId>google-http-client</artifactId>
+        <version>${google-http-client.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Google HTTP Client is used in version 1.4.7 in Quarkus, whereas Google requires the 2.2.0 version. The 2.2.0 has been added to our parent pom, because otherwise the Quarkus BOM import takes precedence.

Also fixed a dependency convergence between spanner/bigtable/storage for an otel contrib dependency.

@loicmathieu this results in a clean build locally, however I'm a bit hesitant for this fix, is this is a major bump in the http-client version on the quarkus side. I don't have full overview where that dependency is used within the quarkus ecosystem, so no idea what will break for other extensions or core quarkus if we perform this upgrade. 