### PR TITLE
Shim to fix dependency divergence between Firestore and Quarkus

### DIFF
--- a/firestore/deployment/pom.xml
+++ b/firestore/deployment/pom.xml
@@ -36,6 +36,11 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers-gcloud</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.shim</groupId>
+            <artifactId>quarkus-shim-deployment</artifactId>
+            <version>0.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/firestore/runtime/pom.xml
+++ b/firestore/runtime/pom.xml
@@ -68,6 +68,15 @@
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-grpc-common</artifactId>
         </dependency>
+
+        <!-- Quarkus Shim - patches com.google.cloud.firestore.telemetry.EnabledTraceUtil so the
+             patch class lands on the same "base runtime" classloader tier as the class it patches
+             in quarkus:dev, instead of the app's reloadable tier (see EnabledTraceUtilShim). -->
+        <dependency>
+            <groupId>io.quarkiverse.shim</groupId>
+            <artifactId>quarkus-shim</artifactId>
+            <version>0.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/shim/EnabledTraceUtilShim.java
+++ b/firestore/runtime/src/main/java/io/quarkiverse/googlecloudservices/firestore/runtime/shim/EnabledTraceUtilShim.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.googlecloudservices.firestore.runtime.shim;
+
+import com.google.api.core.ApiFunction;
+import com.google.cloud.firestore.telemetry.EnabledTraceUtil;
+
+import io.grpc.ManagedChannelBuilder;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import io.quarkiverse.shim.Shim;
+import io.quarkiverse.shim.ShimFields;
+import io.quarkiverse.shim.ShimReplace;
+
+/**
+ * Patches {@link EnabledTraceUtil#getChannelConfigurator()} so the gRPC channel configurator it
+ * returns wires up OpenTelemetry gRPC instrumentation via this extension's own OpenTelemetry
+ * dependency, rather than whatever conflicting OpenTelemetry libraries may otherwise end up on
+ * the classpath.
+ */
+@Shim(EnabledTraceUtil.class)
+public class EnabledTraceUtilShim {
+
+    @ShimReplace(method = "getChannelConfigurator")
+    public static ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> getChannelConfigurator(EnabledTraceUtil self) {
+        var openTelemetry = ShimFields.<OpenTelemetry> get(self, "openTelemetry");
+        return new PatchedGrpcConfigurator(openTelemetry);
+    }
+
+    public static class PatchedGrpcConfigurator implements ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder> {
+
+        private final OpenTelemetry openTelemetry;
+
+        public PatchedGrpcConfigurator(OpenTelemetry openTelemetry) {
+            this.openTelemetry = openTelemetry;
+        }
+
+        @Override
+        public ManagedChannelBuilder apply(ManagedChannelBuilder builder) {
+            var grpcTelemetry = GrpcTelemetry.create(this.openTelemetry);
+            return builder.intercept(grpcTelemetry.createClientInterceptor());
+        }
+    }
+}


### PR DESCRIPTION
Google Cloud Firestore uses and older version of the otel libraries. These libraries have divergde in API, while still keeping a minor version upgrade. Quarkus new version of the library wins in the maven setup, resulting in NoSuchMethodErrors because firestore tries to use the now non-existing API. This shim rewires the offending part of Google Firestore to use the new API.