### PR TITLE
Fix native setup for FirebaseAdmin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,5 +45,5 @@ jobs:
 
     - name: Build in native
       run: |
-        ./mvnw -B -Pnative package --file integration-tests/main/pom.xml
+        ./mvnw -B -Pnative verify --file integration-tests/pom.xml
 

--- a/firebase-admin/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/admin/deployment/FirebaseAdminBuildSteps.java
+++ b/firebase-admin/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/admin/deployment/FirebaseAdminBuildSteps.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.googlecloudservices.firebase.admin.deployment;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import io.quarkiverse.googlecloudservices.firebase.admin.deployment.authentication.FirebaseAuthConfiguration;
 import io.quarkiverse.googlecloudservices.firebase.admin.runtime.FirebaseAdminProducer;
 import io.quarkiverse.googlecloudservices.firebase.admin.runtime.FirebaseSessionCookieManager;
@@ -11,6 +14,7 @@ import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageConfigBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 public class FirebaseAdminBuildSteps {
 
@@ -54,5 +58,24 @@ public class FirebaseAdminBuildSteps {
                 .addRuntimeInitializedClass("com.google.firebase.internal.ApiClientUtils")
                 .addRuntimeInitializedClass("com.google.firebase.internal.ApiClientUtils$TransportInstanceHolder")
                 .build();
+    }
+
+    /**
+     * Fix for <a href="https://github.com/firebase/firebase-admin-java/issues/800">firebase-admin-java#800</a>
+     * when running FirebaseAdmin in a native environment.
+     */
+    @BuildStep
+    public List<ReflectiveClassBuildItem> registerReflectiveClasses() {
+        List<ReflectiveClassBuildItem> items = new ArrayList<>();
+        items.add(ReflectiveClassBuildItem.builder(
+                "com.google.firebase.auth.internal.GetAccountInfoResponse",
+                "com.google.firebase.auth.internal.GetAccountInfoResponse$User",
+                "com.google.firebase.auth.internal.GetAccountInfoResponse$Provider",
+                "com.google.api.client.json.GenericJson")
+                .constructors(true)
+                .fields(true)
+                .methods(true)
+                .build());
+        return items;
     }
 }

--- a/integration-tests/firebase-admin/pom.xml
+++ b/integration-tests/firebase-admin/pom.xml
@@ -75,4 +75,38 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>native</id>
+            <activation>
+                <property>
+                    <name>native</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <systemProperties>
+                                        <native.image.path>${project.build.directory}/${project.build.finalName}-runner</native.image.path>
+                                    </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <quarkus.package.type>native</quarkus.package.type>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthResourceIT.java
+++ b/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthResourceIT.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.googlecloudservices.it.firebaseadmin;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+
+/**
+ * Integration test version of {@link FirebaseAuthUserResourceTest}. Runs to validate the native-image
+ * fixes for FirebaseAdmin in a native container.
+ */
+@QuarkusIntegrationTest
+class FirebaseAuthResourceIT extends FirebaseAuthUserResourceTest {
+}

--- a/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthResourceTest.java
+++ b/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthResourceTest.java
@@ -2,10 +2,7 @@ package io.quarkiverse.googlecloudservices.it.firebaseadmin;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.blankOrNullString;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.not;
 
 import java.util.Map;
 import java.util.Set;
@@ -21,55 +18,10 @@ import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 
 @QuarkusTest
-class FirebaseAuthResourceTest extends FirebaseAuthTest {
+class FirebaseAuthResourceTest extends FirebaseAuthUserResourceTest {
 
     @Inject
     FirebaseAuth firebaseAuth;
-
-    @Test
-    void shouldCreateUser() {
-        given()
-                .contentType(ContentType.JSON)
-                .queryParam("email", "johndoe@quarkusio.com")
-                .queryParam("displayName", "John Doe")
-                .post("/auth/users/create")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(200)
-                .body("uid", not(blankOrNullString()))
-                .body("email", equalTo("johndoe@quarkusio.com"))
-                .body("displayName", equalTo("John Doe"));
-    }
-
-    @Test
-    void shouldStoreCustomUserClaims() {
-        given()
-                .contentType(ContentType.JSON)
-                .queryParam("uid", "12345")
-                .queryParam("email", "johndoe@quarkusio.com")
-                .queryParam("displayName", "John Doe")
-                .post("/auth/users/create")
-                .then()
-                .log().ifValidationFails()
-                .statusCode(200)
-                .body("uid", equalTo("12345"))
-                .body("customClaims", anEmptyMap());
-
-        given()
-                .contentType(ContentType.JSON)
-                .body(Map.of("role", "admin"))
-                .put("/auth/users/{uid}/claims", 12345)
-                .then()
-                .log().ifValidationFails()
-                .statusCode(204);
-
-        given()
-                .get("/auth/users/{uid}", 12345)
-                .then()
-                .log().ifValidationFails()
-                .statusCode(200)
-                .body("customClaims", hasEntry("role", "admin"));
-    }
 
     @Test
     void shouldHandleRoles() throws FirebaseAuthException {

--- a/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthTest.java
+++ b/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthTest.java
@@ -2,19 +2,27 @@ package io.quarkiverse.googlecloudservices.it.firebaseadmin;
 
 import static io.restassured.RestAssured.given;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 
+/**
+ * Base class for authorization tests.
+ * <p>
+ * {@link ConfigProvider} is used to retreive the config valeus over injection as this also needs to run in a integration
+ * test.
+ */
 public abstract class FirebaseAuthTest {
 
-    @ConfigProperty(name = "quarkus.google.cloud.project-id")
     String projectId;
 
-    @ConfigProperty(name = "quarkus.google.cloud.firebase.auth.emulator-host")
     String emulatorHost;
 
     @BeforeEach
     public void deleteAllAccounts() {
+        projectId = ConfigProvider.getConfig().getValue("quarkus.google.cloud.project-id", String.class);
+        emulatorHost = ConfigProvider.getConfig().getValue("quarkus.google.cloud.firebase.auth.emulator-host",
+                String.class);
+
         var emulatorHostParts = emulatorHost.split(":");
         var port = emulatorHostParts.length == 2 ? Integer.parseInt(emulatorHostParts[1]) : 9099;
 

--- a/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthUserResourceTest.java
+++ b/integration-tests/firebase-admin/src/test/java/io/quarkiverse/googlecloudservices/it/firebaseadmin/FirebaseAuthUserResourceTest.java
@@ -1,0 +1,67 @@
+package io.quarkiverse.googlecloudservices.it.firebaseadmin;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.restassured.http.ContentType;
+
+/**
+ * Base class defining tests for FirebaseAdmin which can be both run as regular tests or as integration tests.
+ * The latter needed to verify native execution behaviour.
+ */
+public abstract class FirebaseAuthUserResourceTest extends FirebaseAuthTest {
+
+    @Test
+    void shouldCreateUser() {
+        given()
+                .contentType(ContentType.JSON)
+                .queryParam("email", "johndoe@quarkusio.com")
+                .queryParam("displayName", "John Doe")
+                .post("/auth/users/create")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body("uid", not(blankOrNullString()))
+                .body("email", equalTo("johndoe@quarkusio.com"))
+                .body("displayName", equalTo("John Doe"));
+    }
+
+    @Test
+    void shouldStoreCustomUserClaims() {
+        given()
+                .contentType(ContentType.JSON)
+                .queryParam("uid", "12345")
+                .queryParam("email", "johndoe@quarkusio.com")
+                .queryParam("displayName", "John Doe")
+                .post("/auth/users/create")
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body("uid", equalTo("12345"))
+                .body("customClaims", anEmptyMap());
+
+        given()
+                .contentType(ContentType.JSON)
+                .body(Map.of("role", "admin"))
+                .put("/auth/users/{uid}/claims", 12345)
+                .then()
+                .log().ifValidationFails()
+                .statusCode(204);
+
+        given()
+                .get("/auth/users/{uid}", 12345)
+                .then()
+                .log().ifValidationFails()
+                .statusCode(200)
+                .body("customClaims", hasEntry("role", "admin"));
+    }
+
+}


### PR DESCRIPTION
Usage of FirebaseAdmin fails in a native environment. These changes should fix that. Note that not all uses have been validated, so we may need other changes than these, but its a start.