### PR TITLE
Add a config property to disable push authentication.

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub.adoc
@@ -283,5 +283,26 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-disable-authentication]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-disable-authentication[`+++quarkus.google.cloud.pubsub.push.disable-authentication+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.disable-authentication+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If set to true, the authentication for the pubsub push endpoint will be disabled. This is not recommended for production environments, however the Pub/Sub emulator does not support authentication, so this option can be used for local development and testing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_DISABLE_AUTHENTICATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_DISABLE_AUTHENTICATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub_quarkus.google.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-pubsub_quarkus.google.adoc
@@ -283,5 +283,26 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-disable-authentication]] [.property-path]##link:#quarkus-google-cloud-pubsub_quarkus-google-cloud-pubsub-push-disable-authentication[`+++quarkus.google.cloud.pubsub.push.disable-authentication+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.pubsub.push.disable-authentication+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+If set to true, the authentication for the pubsub push endpoint will be disabled. This is not recommended for production environments, however the Pub/Sub emulator does not support authentication, so this option can be used for local development and testing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_DISABLE_AUTHENTICATION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_PUBSUB_PUSH_DISABLE_AUTHENTICATION+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/GooglePubSubAuthenticationHandler.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/GooglePubSubAuthenticationHandler.java
@@ -25,15 +25,19 @@ public class GooglePubSubAuthenticationHandler implements Handler<RoutingContext
     private final Optional<String> verificationToken;
     private final String serviceAccountEmail;
     private final TokenVerifier verifier;
+    private final boolean disableAuthentication;
 
     public GooglePubSubAuthenticationHandler(String pubSubEndpoint,
             Optional<String> verificationToken,
             String serviceAccountEmail,
-            TokenVerifier verifier) {
+            TokenVerifier verifier,
+            boolean disableAuthentication) {
+
         this.pubSubEndpoint = pubSubEndpoint;
         this.verificationToken = verificationToken;
         this.serviceAccountEmail = serviceAccountEmail;
         this.verifier = verifier;
+        this.disableAuthentication = disableAuthentication;
     }
 
     public void handle(RoutingContext rc) {
@@ -68,11 +72,19 @@ public class GooglePubSubAuthenticationHandler implements Handler<RoutingContext
             LOGGER.debug("No verification token configured, ignoring check");
         }
 
-        LOGGER.debug("Inspecting authorization header for pubsub request");
-
+        // Remove auth header (if any) to prevent MP-JWT from handling it, regardless of whether
+        // this filter itself goes on to check it.
         var authorizationHeader = rc.request().headers().get("Authorization");
-        // Remove auth header to prevent MP-JWT to handle it.
         rc.request().headers().remove("Authorization");
+
+        if (disableAuthentication) {
+            LOGGER.warn(
+                    "Authentication for the pubsub push endpoint is disabled, this is not recommended for production environments");
+            rc.next();
+            return;
+        }
+
+        LOGGER.debug("Inspecting authorization header for pubsub request");
 
         if (Strings.isNullOrEmpty(authorizationHeader)) {
             LOGGER.error("No authentication header found, denying the pubsub message");

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRecorder.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRecorder.java
@@ -43,7 +43,8 @@ public class PubSubPushRecorder {
                 endpoint,
                 config.getValue().verificationToken(),
                 config.getValue().serviceAccountEmail().orElseThrow(),
-                tokenVerifier));
+                tokenVerifier,
+                config.getValue().disableAuthentication()));
     }
 
     public Handler<RoutingContext> authHandlerInstance(RuntimeValue<GooglePubSubAuthenticationHandler> authHandler) {

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRuntimeConfig.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushRuntimeConfig.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
 
 @ConfigMapping(prefix = "quarkus.google.cloud.pubsub.push")
 @ConfigRoot(phase = ConfigPhase.RUN_TIME)
@@ -28,4 +29,12 @@ public interface PubSubPushRuntimeConfig {
      * contain this email address when Google PubSub calls the push-endpoint.
      */
     Optional<String> serviceAccountEmail();
+
+    /**
+     * If set to true, the authentication for the pubsub push endpoint will be disabled. This is not recommended for
+     * production environments, however the Pub/Sub emulator does not support authentication, so this option can be used
+     * for local development and testing.
+     */
+    @WithDefault("false")
+    boolean disableAuthentication();
 }


### PR DESCRIPTION
PubSub emulator does not support authentication, so in a test scenario when using push, we need to disable the auth.