### PR TITLE
Fix index google-cloud-firestore and this extension's own runtime jar for quarkus-shim

### DIFF
--- a/firestore/deployment/src/main/java/io/quarkiverse/googlecloudservices/firestore/deployment/FirestoreBuildSteps.java
+++ b/firestore/deployment/src/main/java/io/quarkiverse/googlecloudservices/firestore/deployment/FirestoreBuildSteps.java
@@ -4,6 +4,7 @@ import io.quarkiverse.googlecloudservices.firestore.runtime.FirestoreProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 
 public class FirestoreBuildSteps {
     protected static final String FEATURE = "google-cloud-firestore";
@@ -16,5 +17,24 @@ public class FirestoreBuildSteps {
     @BuildStep
     public AdditionalBeanBuildItem producer() {
         return new AdditionalBeanBuildItem(FirestoreProducer.class);
+    }
+
+    /**
+     * google-cloud-firestore is a plain third-party jar, not a Quarkus extension, so Quarkus never
+     * Jandex-indexes it on its own. EnabledTraceUtilShim's {@code @Shim} targets
+     * {@code EnabledTraceUtil} in that jar
+     */
+    @BuildStep
+    public IndexDependencyBuildItem indexGoogleCloudFirestoreForShim() {
+        return new IndexDependencyBuildItem("com.google.cloud", "google-cloud-firestore");
+    }
+
+    /**
+     * Make sure that the runtime jar of this extension is indexed, so that {@code FirestoreProducer} can be found by
+     * {@code @Shim}
+     */
+    @BuildStep
+    public IndexDependencyBuildItem indexOwnRuntimeJarForShim() {
+        return new IndexDependencyBuildItem("io.quarkiverse.googlecloudservices", "quarkus-google-cloud-firestore");
     }
 }

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -10,6 +10,11 @@ quarkus.google.cloud.project-id=test-project
 quarkus.google.cloud.access-token-enabled=false
 quarkus.google.cloud.storage.host-override=http://localhost:8089
 
+# Written to target/shim/shim-report.txt at build time; FirestoreShimAppliedTest asserts on it to
+# catch a shim silently never being applied (e.g. because its target isn't indexed) instead of
+# only finding out via a runtime NoSuchMethodError on some rarely-exercised code path.
+quarkus.shim.report=true
+
 # Specific profile for pubsub push
 %push.quarkus.google.cloud.pubsub.push.enabled=true
 %push.quarkus.google.cloud.pubsub.push.audience=test-demo-audience

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/FirestoreShimAppliedTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/FirestoreShimAppliedTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.googlecloudservices.it;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * quarkus-shim (via quarkus.shim.report=true, see application.properties) writes a summary of
+ * every shim it actually wove into a class at build time. EnabledTraceUtilShim targets
+ * com.google.cloud.firestore.telemetry.EnabledTraceUtil, a class in the plain third-party
+ * google-cloud-firestore jar -- not a Quarkus extension, so Quarkus never Jandex-indexes it on its
+ * own. Without indexing it, quarkus-shim silently never applies this patch at all (or, on a
+ * quarkus-shim version whose validation is stricter, fails the build outright)
+ */
+@QuarkusTest
+public class FirestoreShimAppliedTest {
+
+    @Test
+    public void shimReportShowsFirestoreTelemetryShimApplied() throws IOException {
+        Path report = Path.of("target", "shim-report.txt");
+        if (!Files.exists(report)) {
+            fail("target/shim-report.txt was not written -- is quarkus.shim.report=true still set"
+                    + " in application.properties?");
+        }
+        String content = Files.readString(report);
+        assertTrue(
+                content.contains("com.google.cloud.firestore.telemetry.EnabledTraceUtil")
+                        && content.contains("EnabledTraceUtilShim"),
+                "Expected the Firestore telemetry shim to be applied, but it wasn't found in the shim report:\n"
+                        + content);
+    }
+}


### PR DESCRIPTION
Regression: the missing Jandex since 0.4.0 shim resulted in the Shim not being applied. Added a fix for this and a test to verify the behaviour

Added test to verify shim is applied
Added indexing so shim is applied, since 0.4.0 this didn't work (silently), the regression test should no signal this.