### PR TITLE
Implement support for end-to-end testing using pubsub and push

### DIFF
--- a/docs/modules/ROOT/pages/pubsub.adoc
+++ b/docs/modules/ROOT/pages/pubsub.adoc
@@ -201,10 +201,16 @@ in the `MessageReceiver` interface.
 
 When running quarkus-tests, messages will also be authenticated, which will fail as you cannot provide a valid JWT
 signed with the Google private keys. To resolve this issue, there are two options:
+
 * Using pull-subscriptions for testing purposes. For the `%test` profile, set the `quarkus.google.cloud.pubsub.push.enabed` flag to false. This
   will result in the code using pull messages instead of push messages without any underlying code changes
-* Use a mock implementation of the `TokenVerifier` class as can be seen in the `PubSubPushResourceTest` in the
-  integration tests of this extension.
+* Disable authentication (as the emulator does not support this) and use true end-to-end testing of push messages. To
+  register the subscriptions `QuarkusPubSub` provides a `createPushSubscription` method which can be used to create a push subscription with the correct endpoint and authentication credentials. The devservices will automatically register
+  `host.docker.internal` (which is not present on Linux) as the container url for push subscriptions. This can be used
+  as the hostname to register the push subscription to. Note
+
+_Note that when running a `@QuarkusIntegrationTest` where the quarkus app is running in a container, you need to use the
+shared network container name as the hostname._
 
 Consult the https://cloud.google.com/pubsub/docs/push[Google Cloud PubSub push] documentation for more information on
 the push model, configuring the topics and subscriptions and configuring authentication.

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
@@ -1091,6 +1091,13 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
         this.afterStart = emulatorConfig.dockerConfig().afterStart();
         this.useSharedNetwork = emulatorConfig.dockerConfig().useSharedNetwork();
 
+        // Configure host.docker.internal for non-shared network mode, so that the container can reach the host machine
+        // This needed as e.g. hosting needs to reach the host machine for API calls. Linux doesn't have
+        // host.docker.internal by default, so we add it here.
+        if (!useSharedNetwork) {
+            withExtraHost("host.docker.internal", "host-gateway");
+        }
+
         emulatorConfig.cliArguments().emulatorData().ifPresent(path -> {
             // https://firebase.google.com/docs/emulator-suite/install_and_configure#export_and_import_emulator_data
             // Mount the volume to the specified path

--- a/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/PubSubPushResource.java
+++ b/integration-tests/main/src/main/java/io/quarkiverse/googlecloudservices/it/PubSubPushResource.java
@@ -2,36 +2,38 @@ package io.quarkiverse.googlecloudservices.it;
 
 import java.io.IOException;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
 import com.google.api.core.ApiService;
 import com.google.cloud.pubsub.v1.MessageReceiver;
 
 import io.quarkiverse.googlecloudservices.pubsub.QuarkusPubSub;
-import io.quarkus.runtime.Startup;
+import io.quarkus.runtime.StartupEvent;
 
 @Path("/pubsub-push")
-@Startup
 public class PubSubPushResource {
     private static final Logger LOG = Logger.getLogger(PubSubResource.class);
 
     @Inject
     QuarkusPubSub pubSub;
 
-    private ApiService subscriber;
-    private String lastMessage;
+    @ConfigProperty(name = "quarkus.google.cloud.pubsub.push.enabled")
+    boolean pushEnabled;
 
-    @PostConstruct
-    void init() throws IOException {
-        // init topic and subscription
-        pubSub.createTopic("test-push-topic");
-        pubSub.createSubscription("test-push-topic", "test-push-subscription");
+    private ApiService subscriber;
+    private String lastMessage = "NO MESSAGE YET";
+
+    public void init(@Observes StartupEvent ev) throws IOException {
+        if (!pushEnabled) {
+            return;
+        }
 
         // subscribe to PubSub
         MessageReceiver receiver = (message, consumer) -> {

--- a/integration-tests/main/src/main/resources/application.properties
+++ b/integration-tests/main/src/main/resources/application.properties
@@ -17,6 +17,15 @@ quarkus.google.cloud.storage.host-override=http://localhost:8089
 %push.quarkus.google.cloud.pubsub.push.verification-token=testtoken
 %push.quarkus.google.cloud.pubsub.push.service-account-email=testme@google.com
 
+# Specific profile for pubsub push
+%push-e2e.quarkus.google.cloud.pubsub.push.enabled=true
+%push-e2e.quarkus.google.cloud.pubsub.push.audience=test-demo-audience
+%push-e2e.quarkus.google.cloud.pubsub.push.endpoint-path=/pubsub-push-receiver
+%push-e2e.quarkus.google.cloud.pubsub.push.verification-token=testtoken
+%push-e2e.quarkus.google.cloud.pubsub.push.service-account-email=testme@google.com
+%push-e2e.quarkus.google.cloud.pubsub.push.disable-authentication=true
+%push-e2e.quarkus.http.host=0.0.0.0
+
 # Profile for testing that service-account-email resolves from a runtime env var (not baked in at build time).
 # service-account-email is deliberately absent here; it is supplied only via QuarkusTestProfile.getConfigOverrides().
 %push-runtime-config.quarkus.google.cloud.pubsub.push.enabled=true

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushResourceE2ETest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushResourceE2ETest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.googlecloudservices.it;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.pubsub.v1.PubsubMessage;
+
+import io.quarkiverse.googlecloudservices.pubsub.QuarkusPubSub;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest()
+@TestProfile(PubSubPushResourceE2ETest.Profile.class)
+public class PubSubPushResourceE2ETest {
+
+    @Inject
+    QuarkusPubSub pubSub;
+
+    public static final class Profile implements QuarkusTestProfile {
+
+        @Override
+        public String getConfigProfile() {
+            return "push-e2e";
+        }
+
+    }
+
+    @BeforeEach
+    public void setup() throws IOException {
+        pubSub.createTopicsAndPushSubscriptions(Map.of("test-push-topic", List.of("test-push-subscription")));
+    }
+
+    @Test
+    public void testPushUsingPublisher() throws IOException {
+        String message = "Hello Pub/Sub";
+
+        var publisher = pubSub.publisher("test-push-topic");
+        var pubsubMessage = PubsubMessage.newBuilder()
+                .setData(com.google.protobuf.ByteString.copyFromUtf8(message))
+                .build();
+
+        publisher.publish(pubsubMessage);
+
+        await().atMost(3, TimeUnit.SECONDS)
+                .untilAsserted(() -> given()
+                        .when().get("/pubsub-push")
+                        .then()
+                        .statusCode(200)
+                        .body(equalTo(message)));
+    }
+
+}

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushResourceTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushResourceTest.java
@@ -4,22 +4,27 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.core.IsEqual.equalTo;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Priority;
-
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 
+import io.quarkiverse.googlecloudservices.pubsub.QuarkusPubSub;
 import io.quarkiverse.googlecloudservices.pubsub.push.TokenVerifier;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -32,6 +37,9 @@ public class PubSubPushResourceTest {
 
     @ConfigProperty(name = "quarkus.google.cloud.project-id")
     String projectId;
+
+    @Inject
+    QuarkusPubSub pubSub;
 
     public static final class Profile implements QuarkusTestProfile {
 
@@ -77,6 +85,12 @@ public class PubSubPushResourceTest {
                     new byte[0],
                     new byte[0]);
         }
+    }
+
+    @BeforeEach
+    public void setup() throws IOException {
+        pubSub.createTopicsAndPushSubscriptions(Map.of("test-push-topic", List.of("test-push-subscription")),
+                "host.docker.internal");
     }
 
     @Test

--- a/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushRuntimeConfigTest.java
+++ b/integration-tests/main/src/test/java/io/quarkiverse/googlecloudservices/it/PubSubPushRuntimeConfigTest.java
@@ -1,6 +1,8 @@
 package io.quarkiverse.googlecloudservices.it;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
@@ -11,6 +13,7 @@ import javax.annotation.Priority;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import com.google.api.client.json.webtoken.JsonWebSignature;
 
+import io.quarkiverse.googlecloudservices.pubsub.push.PubSubPushManager;
 import io.quarkiverse.googlecloudservices.pubsub.push.TokenVerifier;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -39,6 +43,9 @@ public class PubSubPushRuntimeConfigTest {
 
     @ConfigProperty(name = "quarkus.google.cloud.project-id")
     String projectId;
+
+    @Inject
+    PubSubPushManager pushManager;
 
     public static final class Profile implements QuarkusTestProfile {
 
@@ -121,6 +128,17 @@ public class PubSubPushRuntimeConfigTest {
                 .when().post("/pubsub-push-receiver?token=testtoken")
                 .then()
                 .statusCode(401);
+    }
+
+    @Test
+    public void testEndpointUrl() {
+        var uri = pushManager.getEndpointUrl("my-host");
+
+        assertThat(uri.getScheme(), is("http"));
+        assertThat(uri.getHost(), is("my-host"));
+        assertThat(uri.getPort(), is(8081));
+        assertThat(uri.getPath(), is("/pubsub-push-receiver"));
+        assertThat(uri.getQuery(), is("token=testtoken"));
     }
 
     private String createMessage(String message) {

--- a/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployment/PubSubDevServiceProcessor.java
+++ b/pubsub/deployment/src/main/java/io/quarkiverse/googlecloudservices/pubsub/deployment/PubSubDevServiceProcessor.java
@@ -8,6 +8,7 @@ import org.jboss.logging.Logger;
 import org.testcontainers.gcloud.PubSubEmulatorContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import io.quarkiverse.googlecloudservices.pubsub.push.PubSubPushBuildTimeConfig;
 import io.quarkus.deployment.IsProduction;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.BuildSteps;
@@ -37,6 +38,7 @@ public class PubSubDevServiceProcessor {
     public DevServicesResultBuildItem start(
             DockerStatusBuildItem dockerStatusBuildItem,
             PubSubDevServiceConfig devServiceConfig,
+            PubSubPushBuildTimeConfig pushConfig,
             FirebaseDevServiceConfig firebaseConfig,
             DevServicesComposeProjectBuildItem composeProjectBuildItem,
             List<DevServicesSharedNetworkBuildItem> devServicesSharedNetworkBuildItem,
@@ -62,7 +64,7 @@ public class PubSubDevServiceProcessor {
         try {
             boolean useSharedNetwork = DevServicesSharedNetworkBuildItem.isSharedNetworkRequired(devServicesConfig,
                     devServicesSharedNetworkBuildItem);
-            devService = startContainerIfAvailable(dockerStatusBuildItem, devServiceConfig,
+            devService = startContainerIfAvailable(dockerStatusBuildItem, devServiceConfig, pushConfig,
                     firebaseConfig, devServicesConfig.timeout(), composeProjectBuildItem, useSharedNetwork);
         } catch (Throwable t) {
             LOGGER.warn("Unable to start PubSub dev service", t);
@@ -89,6 +91,7 @@ public class PubSubDevServiceProcessor {
     private DevServicesResultBuildItem.RunningDevService startContainerIfAvailable(
             DockerStatusBuildItem dockerStatusBuildItem,
             PubSubDevServiceConfig config,
+            PubSubPushBuildTimeConfig pushConfig,
             FirebaseDevServiceConfig firebaseConfig,
             Optional<Duration> timeout,
             DevServicesComposeProjectBuildItem composeProjectBuildItem,
@@ -110,7 +113,7 @@ public class PubSubDevServiceProcessor {
             return null;
         }
 
-        return startContainer(dockerStatusBuildItem, config, timeout, composeProjectBuildItem, useSharedNetwork);
+        return startContainer(dockerStatusBuildItem, config, pushConfig, timeout, composeProjectBuildItem, useSharedNetwork);
     }
 
     /**
@@ -118,6 +121,7 @@ public class PubSubDevServiceProcessor {
      *
      * @param dockerStatusBuildItem, Docker status
      * @param config, Configuration for the PubSub service
+     * @param pushConfig The push configuration for the PubSub service
      * @param timeout, Optional timeout for starting the service
      * @param composeProjectBuildItem The compose build item
      * @param useSharedNetwork Start the service on a shared docker network
@@ -126,6 +130,7 @@ public class PubSubDevServiceProcessor {
     private DevServicesResultBuildItem.RunningDevService startContainer(
             DockerStatusBuildItem dockerStatusBuildItem,
             PubSubDevServiceConfig config,
+            PubSubPushBuildTimeConfig pushConfig,
             Optional<Duration> timeout,
             DevServicesComposeProjectBuildItem composeProjectBuildItem,
             boolean useSharedNetwork) {
@@ -135,7 +140,8 @@ public class PubSubDevServiceProcessor {
                         .asCompatibleSubstituteFor("gcr.io/google.com/cloudsdktool/cloud-sdk:emulators"),
                 config.emulatorPort().orElse(null),
                 composeProjectBuildItem.getDefaultNetworkId(),
-                useSharedNetwork);
+                useSharedNetwork,
+                pushConfig.enabled());
 
         // Set container startup timeout if provided
         timeout.ifPresent(emulatorContainer::withStartupTimeout);
@@ -174,15 +180,17 @@ public class PubSubDevServiceProcessor {
 
         private final Integer fixedExposedPort;
         private final boolean useSharedNetwork;
+        private final boolean usePush;
         private final String hostName;
         private static final int INTERNAL_PORT = 8085;
 
         private QuarkusPubSubContainer(DockerImageName dockerImageName, Integer fixedExposedPort,
-                String defaultNetworkId, boolean useSharedNetwork) {
+                String defaultNetworkId, boolean useSharedNetwork, boolean usePush) {
             super(dockerImageName);
             this.fixedExposedPort = fixedExposedPort;
             this.useSharedNetwork = useSharedNetwork;
             this.hostName = ConfigureUtil.configureNetwork(this, defaultNetworkId, useSharedNetwork, "pubsub");
+            this.usePush = usePush;
         }
 
         /**
@@ -193,6 +201,10 @@ public class PubSubDevServiceProcessor {
             super.configure();
             if (useSharedNetwork) {
                 return;
+            }
+
+            if (usePush) {
+                withExtraHost("host.docker.internal", "host-gateway");
             }
 
             // Expose Pub/Sub emulatorPort

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/QuarkusPubSub.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/QuarkusPubSub.java
@@ -1,8 +1,11 @@
 package io.quarkiverse.googlecloudservices.pubsub;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import jakarta.annotation.PostConstruct;
@@ -217,6 +220,82 @@ public class QuarkusPubSub {
             return existing.orElseGet(() -> subscriptionAdminClient.createSubscription(subscriptionName, topicName,
                     PushConfig.getDefaultInstance(), 0));
         }
+    }
+
+    /**
+     * Creates a PubSub Push Subscription if not already exist, using the configured project ID.
+     */
+    public Subscription createPushSubscription(String topic, String subscription, String host) throws IOException {
+        SubscriptionName subscriptionName = SubscriptionName.of(
+                gcpConfigHolder.getBootstrapConfig().projectId().orElseThrow(),
+                subscription);
+        TopicName topicName = TopicName.of(gcpConfigHolder.getBootstrapConfig().projectId().orElseThrow(), topic);
+        SubscriptionAdminSettings subscriptionAdminSettings = subscriptionAdminSettings();
+
+        try (SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient
+                .create(subscriptionAdminSettings)) {
+            Iterable<Subscription> subscriptions = subscriptionAdminClient
+                    .listSubscriptions(ProjectName.of(gcpConfigHolder.getBootstrapConfig().projectId().orElseThrow()))
+                    .iterateAll();
+            Optional<Subscription> existing = StreamSupport.stream(subscriptions.spliterator(), false)
+                    .filter(sub -> sub.getName().equals(subscriptionName.toString()))
+                    .findFirst();
+            return existing.orElseGet(() -> subscriptionAdminClient.createSubscription(subscriptionName, topicName,
+                    PushConfig.newBuilder()
+                            .setPushEndpoint(pushManager.get().getEndpointUrl(host).toString())
+                            .build(),
+                    0));
+        }
+    }
+
+    /**
+     * Convenience method to create topics and subscriptions for the given map of topic names and subscription names.
+     */
+    public Collection<Subscription> createTopicsAndSubscriptions(Map<String, Collection<String>> topicsAndSubscriptions) {
+        return internalCreateTopicsAndSubscriptions(topicsAndSubscriptions, this::createSubscription);
+    }
+
+    /**
+     * Convenience method to create topics and push subscriptions for the given map of topic names and subscription names.
+     */
+    public Collection<Subscription> createTopicsAndPushSubscriptions(Map<String, Collection<String>> topicsAndSubscriptions,
+            String host) {
+        return internalCreateTopicsAndSubscriptions(topicsAndSubscriptions,
+                (topic, name) -> createPushSubscription(topic, name, host));
+    }
+
+    /**
+     * Convenience method to create topics and push subscriptions for the given map of topic names and subscription names,
+     * using <code>host.docker.internal</code> as hostname.
+     */
+    public Collection<Subscription> createTopicsAndPushSubscriptions(Map<String, Collection<String>> topicsAndSubscriptions) {
+        return createTopicsAndPushSubscriptions(topicsAndSubscriptions, "host.docker.internal");
+    }
+
+    @FunctionalInterface
+    private interface SubscriptionCreator {
+        Subscription create(String topic, String subscription) throws IOException;
+    }
+
+    private Collection<Subscription> internalCreateTopicsAndSubscriptions(
+            Map<String, Collection<String>> topicsAndSubscriptions, SubscriptionCreator subscriptionCreator) {
+        return topicsAndSubscriptions.entrySet().stream().flatMap(entry -> {
+            try {
+                var topicName = entry.getKey();
+                createTopic(topicName);
+                return entry.getValue()
+                        .stream()
+                        .map(name -> {
+                            try {
+                                return subscriptionCreator.create(topicName, name);
+                            } catch (IOException e) {
+                                throw new IllegalStateException(e);
+                            }
+                        });
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
+        }).collect(Collectors.toList());
     }
 
     private CredentialsProvider credentialsProvider() {

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/GooglePubSubAuthenticationHandler.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/GooglePubSubAuthenticationHandler.java
@@ -20,6 +20,7 @@ import io.vertx.ext.web.RoutingContext;
 public class GooglePubSubAuthenticationHandler implements Handler<RoutingContext> {
 
     private static final Logger LOGGER = Logger.getLogger(GooglePubSubAuthenticationHandler.class);
+    public static final String VERIFICATION_TOKEN_NAME = "token";
 
     private final String pubSubEndpoint;
     private final Optional<String> verificationToken;
@@ -61,9 +62,10 @@ public class GooglePubSubAuthenticationHandler implements Handler<RoutingContext
 
         if (verificationToken.isPresent()) {
             String pubsubVerificationToken = verificationToken.get();
-            var receivedToken = rc.queryParam("token");
+            var receivedToken = rc.queryParam(VERIFICATION_TOKEN_NAME);
             // Do not process message if request token does not match pubsubVerificationToken
-            if (receivedToken.size() != 1 || pubsubVerificationToken.compareTo(rc.queryParam("token").get(0)) != 0) {
+            if (receivedToken.size() != 1
+                    || pubsubVerificationToken.compareTo(rc.queryParam(VERIFICATION_TOKEN_NAME).get(0)) != 0) {
                 LOGGER.warn("The request did not contain the required verification token, denying the pubsub message");
                 rc.fail(401);
                 return;

--- a/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushManager.java
+++ b/pubsub/runtime/src/main/java/io/quarkiverse/googlecloudservices/pubsub/push/PubSubPushManager.java
@@ -1,9 +1,17 @@
 package io.quarkiverse.googlecloudservices.pubsub.push;
 
+import static io.quarkiverse.googlecloudservices.pubsub.push.GooglePubSubAuthenticationHandler.VERIFICATION_TOKEN_NAME;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -14,6 +22,8 @@ import com.google.cloud.pubsub.v1.MessageReceiver;
 import com.google.cloud.pubsub.v1.SubscriberInterface;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
+
+import io.quarkus.vertx.http.HttpServer;
 
 /**
  * This class manages pub-sub push subscriptions (see <a href="https://cloud.google.com/pubsub/docs/push">here</a>).
@@ -33,6 +43,70 @@ public class PubSubPushManager {
 
     @ConfigProperty(name = "quarkus.google.cloud.pubsub.push.enabled")
     boolean enabled;
+
+    @ConfigProperty(name = "quarkus.google.cloud.pubsub.push.endpoint-path")
+    Optional<String> endpointPath;
+
+    @ConfigProperty(name = "quarkus.google.cloud.pubsub.push.verification-token")
+    Optional<String> verificationToken;
+
+    @Inject
+    Instance<HttpServer> httpServer;
+
+    /**
+     * Get the endpoint URL for the push subscription. This can be used for testing to configure the push endpoints
+     * for the subscriptions. Note that this method will throw an exception if push is not enabled or if the endpoint
+     * path is not configured.
+     * <p/>
+     * The host parameter is typically <code>localhost</code>, however when e.g. running in an integration test setup,
+     * the container much be made available through TestContainer#expostHostPort(), in which case the host paramter
+     * is set to "host.testcontainers.internal".
+     * <p/>
+     * This method will use the configured HTTP server to determine the port and scheme (http or https) to use for the
+     * endpoint URL.
+     * <p/>
+     * Note that this method will throw an exception if the HTTP server is not available or if the port cannot be
+     * determined.
+     * <p/>
+     * This method will also append the verification token as a query parameter if it is configured.
+     *
+     * @param host The host name to use for the endpoint URL. This is typically the public hostname of the application.
+     * @return The endpoint URL for the push subscription
+     */
+    public URI getEndpointUrl(String host) {
+        if (!enabled) {
+            throw new IllegalStateException("Cannot get the endpoint URL when push is not enabled");
+        }
+        if (endpointPath.isEmpty()) {
+            throw new IllegalStateException(
+                    "Cannot get the endpoint URL when push is enabled but no endpoint path is configured");
+        }
+
+        var httpServerInstance = httpServer.get();
+
+        var port = httpServerInstance.getPort();
+        var scheme = "http";
+        if (port == -1) {
+            port = httpServerInstance.getSecurePort();
+            scheme = "https";
+            if (port == -1) {
+                throw new IllegalStateException(
+                        "Cannot get the endpoint URL when push is enabled but no HTTP port can be resolved");
+            }
+        }
+        try {
+            return new URI(
+                    scheme,
+                    null,
+                    host,
+                    port,
+                    endpointPath.get(),
+                    verificationToken.map(token -> VERIFICATION_TOKEN_NAME + "=" + token).orElse(null),
+                    null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Cannot construct endpoint URL", e);
+        }
+    }
 
     /**
      * Register a receiver for a subscription. Note that we only allow a single receiver per subscription for push


### PR DESCRIPTION
Also adds some convenience methods to create topics and subscriptions for both the pull and push model.

Register host.docker.internal for Linux environments, so the pubsub emulator can access the host machine (when not running in shared network mode)