### PR TITLE
Remove the netty-shaded exclusion as netty-shaded now brings native graal support build-in

### DIFF
--- a/bigquery/runtime/pom.xml
+++ b/bigquery/runtime/pom.xml
@@ -37,12 +37,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>

--- a/bigtable/runtime/pom.xml
+++ b/bigtable/runtime/pom.xml
@@ -36,12 +36,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                     one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>

--- a/common/grpc/pom.xml
+++ b/common/grpc/pom.xml
@@ -16,12 +16,6 @@
             <groupId>com.google.api</groupId>
             <artifactId>gax-grpc</artifactId>
             <exclusions>
-                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included directly
-                 and Quarkus includes the netty library -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>

--- a/common/runtime/pom.xml
+++ b/common/runtime/pom.xml
@@ -69,6 +69,15 @@
             <groupId>org.graalvm.sdk</groupId>
             <artifactId>nativeimage</artifactId>
         </dependency>
+        <!-- Compile-time only: needed to reference the shaded Netty logging class in the
+             GraalVM substitution below. Extensions that end up with grpc-netty-shaded on
+             their runtime classpath (transitively, via their own GCP client) get the fix;
+             ones that don't simply never trigger the substitution. -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/runtime/graal/InternalLoggerFactorySubstitution.java
+++ b/common/runtime/src/main/java/io/quarkiverse/googlecloudservices/common/runtime/graal/InternalLoggerFactorySubstitution.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.googlecloudservices.spanner.runtime.graal;
+package io.quarkiverse.googlecloudservices.common.runtime.graal;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
@@ -7,6 +7,11 @@ import io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory
 
 @TargetClass(className = "io.grpc.netty.shaded.io.netty.util.internal.logging.InternalLoggerFactory")
 public final class InternalLoggerFactorySubstitution {
+    @Substitute
+    private static InternalLoggerFactory useLog4J2LoggerFactory(String name) {
+        return null;
+    }
+
     @Substitute
     private static InternalLoggerFactory useLog4JLoggerFactory(String name) {
         return null;

--- a/firebase-admin/runtime/pom.xml
+++ b/firebase-admin/runtime/pom.xml
@@ -37,12 +37,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included via
-quarkus-google-cloud-common-grpc and Quarkus include the netty library -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/firebase-devservices/deployment/pom.xml
+++ b/firebase-devservices/deployment/pom.xml
@@ -53,14 +53,6 @@
             <groupId>com.google.firebase</groupId>
             <artifactId>firebase-admin</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included via
-quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -89,12 +81,6 @@ quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>
@@ -117,12 +103,6 @@ quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
                 <exclusion>
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
-                </exclusion>
-                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included via
-                quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>

--- a/firestore/runtime/pom.xml
+++ b/firestore/runtime/pom.xml
@@ -37,12 +37,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>

--- a/logging/runtime/pom.xml
+++ b/logging/runtime/pom.xml
@@ -38,10 +38,6 @@
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>
                 </exclusion>

--- a/pubsub/runtime/pom.xml
+++ b/pubsub/runtime/pom.xml
@@ -37,12 +37,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included via
-                quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>

--- a/secret-manager/runtime/pom.xml
+++ b/secret-manager/runtime/pom.xml
@@ -37,12 +37,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library and include only the grpc-netty
-                one (coming from quarkus-google-cloud-common-grpc) as netty is already included with Quarkus -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>animal-sniffer-annotations</artifactId>

--- a/storage/runtime/pom.xml
+++ b/storage/runtime/pom.xml
@@ -33,12 +33,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included via
-                quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/vertx-ai/runtime/pom.xml
+++ b/vertx-ai/runtime/pom.xml
@@ -33,12 +33,6 @@
                     <groupId>org.checkerframework</groupId>
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
-                <!-- We exclude the grpc-netty-shaded library as grpc-netty is included via
-                quarkus-google-cloud-common-grpc and Quarkus includes the netty library -->
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-netty-shaded</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
Moved the loggerfactory substituion to common-runtime, so it can be shared across modules, not just spanner.

@loicmathieu looks like this might do the trick w.r.t. the native compilation issue.