### PR TITLE
Add support for override the hosting and functions paths when using a custom firebase.json file

### DIFF
--- a/docs/modules/ROOT/pages/firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/firebase-devservices.adoc
@@ -157,6 +157,33 @@ If emulators are configured via the configuration options, a `firebase.json` fil
 * Each of the emulators must be exposed on `0.0.0.0` as host as described https://firebase.google.com/docs/emulator-suite/use_hosting#emulators-no-local-host[here]. If this is not done, the Emulators will not be reachable from the Docker host.
 * Emulators need to be configured to use the default ports. Customizing the ports on which they run is currently not supported (this might change in a future version).
 
+=== Overriding the hosting/functions path from config
+
+The TestContainers Docker container running the emulator mounts a number of files and directories (depending on which emulators you enabled):
+
+* The hosting directory (only when using the hosting emulator)
+* The functions directory (only when using the functions emulator)
+* The emulator data (only when importing data into Firestore)
+
+These directories are mounted based on the path relative to the `firebase.json` file. Docker volume mounts are used, as
+
+1. these directories contain a lot of data (`node_modules` directory most notably), where the data into the container would impose a significant delay or
+2. data needs also to be written back to the host environment (when exporting data from Firestore)
+
+Volume mounts are known to cause issues in when running on CI environments, where the path to be mounted cannot be determined automatically. This is especially the case when sharing Docker sockets to another container or using a Docker-inside-Docker setup.
+
+If you hit this, you can override these directories using the config properties for the devservices setup instead as shown below. (_Note: the emulator data location is not read from `firebase.json`, so no override exists for this, just use the regular config property._ )
+
+[source,properties]
+----
+# e.g. exported by the pipeline to the one absolute path both the build container and the host agent agree on;
+# defaults to "." so nothing changes for a plain local run
+quarkus.google.cloud.devservices.firebase.hosting.hosting-path=${PROJECT_ROOT:.}/my-frontend
+quarkus.google.cloud.devservices.functions.functions-path=${PROJECT_ROOT:.}/functions
+----
+
+When set, these take precedence over the custom firebase.json's own `hosting.public`/`hosting.source` and `functions.source` -- everything else in that file (rewrites, headers, ignore patterns, rule file references, ...) is unaffected.
+
 == Connectivity
 
 Each emulator's address is exposed to your application through two config properties, because which one is

--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices.adoc
@@ -592,7 +592,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Path to the hosting files.
+Path to the hosting files. Takes precedence over a custom firebase.json's own `hosting.public`/`hosting.source`, if `quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json` is also set -- see the docs section on Custom Firebase JSON for why you may need this.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -815,6 +815,963 @@ Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_EMULATOR_PO
 endif::add-copy-button-to-env-var[]
 --
 |int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled[`+++quarkus.google.cloud.devservices.pubsub.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.pubsub.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-emulator-port[`+++quarkus.google.cloud.devservices.pubsub.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.pubsub.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-enabled[`+++quarkus.google.cloud.devservices.storage.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.storage.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-emulator-port[`+++quarkus.google.cloud.devservices.storage.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.storage.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-rules-file]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-rules-file[`+++quarkus.google.cloud.devservices.storage.rules-file+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.storage.rules-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the storage.rules file.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_RULES_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_RULES_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-project-id]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-project-id[`+++quarkus.google.cloud.devservices.project-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.project-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Google Cloud project ID. The project is required to be set if you use the Firebase Auth Dev service.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PROJECT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PROJECT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-prefer-firebase-dev-services]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-prefer-firebase-dev-services[`+++quarkus.google.cloud.devservices.firebase.prefer-firebase-dev-services+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.prefer-firebase-dev-services+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates to use the dev service for Firebase. The default value is true. This indicator is used to detect the Firebase DevService and disable the DevServices for extensions which conflict with the Firebase DevService.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_PREFER_FIREBASE_DEV_SERVICES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_PREFER_FIREBASE_DEV_SERVICES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-firebase-version]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-firebase-version[`+++quarkus.google.cloud.devservices.firebase.emulator.firebase-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.firebase-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The version of the firebase tools to use. Default is to auto-detect it from a package.json file or else use the latest available version.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_FIREBASE_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_FIREBASE_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-image-name]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-image-name[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.image-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the Docker image name for the Google Cloud SDK. This image is used to emulate the Pub/Sub service in the development environment. The default value is 'node:23-alpine'.
+
+See also the documentation on Custom Docker images for more info about this image.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++node:20-alpine+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Id of the docker user to run the firebase executable. This is needed in environments where Docker does not perform a mapping to the user running Docker. In a Docker Desktop setup, Docker automatically performs this mapping and the data written by the emulator can be read by the user running the build. This is not the case in a regular (non-Desktop) setup, so you may need to set the user id and `docker-group()`. This option is often needed in CI environments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Id of the group to which the `docker-user()` belongs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user-env]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user-env[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user-env+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user-env+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Try to read the `docker-user()` from an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER_ENV+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER_ENV+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group-env]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group-env[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group-env+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group-env+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Try to read the `docker-group()` from an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP_ENV+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP_ENV+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-auto-detect-user-and-group]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-auto-detect-user-and-group[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.auto-detect-user-and-group+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.auto-detect-user-and-group+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Automatically try to detect the `docker-user()` and `docker-group()` based on the current user. This is the default. Note that this setting is overridden by any of the previous ways to set the uid/gid.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_AUTO_DETECT_USER_AND_GROUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_AUTO_DETECT_USER_AND_GROUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-out]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-out[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-out+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-out+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Pipe Stdout of the container to the Quarkus logging
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_OUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_OUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-err]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-err[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-err+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-err+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Pipe Stedd of the container to the Quarkus logging
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_ERR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_ERR+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+List of additional environment variables and values which can be passed into the docker image. These variables can be picked up by some webframeworks or functions (see the firebase documentation). This feature can e.g. be used to pass in for example the port the Quarkus application is exposing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The token to use for firebase authentication. Run `firebase login:ci` locally to get a new token. This option is mandatory if you use firebase hosting.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-java-tool-options]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-java-tool-options[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.java-tool-options+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.java-tool-options+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the JAVA tool options for emulators based on the Java runtime environment like -Xmx. See also link:https://firebase.google.com/docs/emulator-suite/install_and_configure#specifying_java_options[here]
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_JAVA_TOOL_OPTIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_JAVA_TOOL_OPTIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-emulator-data]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-emulator-data[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.emulator-data+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.emulator-data+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Allow to import and export data. Specify a path relative to the current working directory of the executable (for most unit tests, this is the root of the build directory) to be used for import and export of emulator data. The data will be written to a subdirectory called "emulator-data" of this directory. See also link:https://firebase.google.com/docs/emulator-suite/install_and_configure#export_and_import_emulator_data[here]
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EMULATOR_DATA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EMULATOR_DATA+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-import-export]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-import-export[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.import-export+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.import-export+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicate whether to import, export or both the data specified in `emulator-data()`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_IMPORT_EXPORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_IMPORT_EXPORT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`import-only`, `export-only`, `import-export`
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-experiments]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-experiments[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.experiments+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.experiments+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates the set of experimental features from firebase to enable (using the firebase experiment:enable command line option).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EXPERIMENTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EXPERIMENTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-debug]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-debug[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.debug+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.debug+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable firebase emulators debugging.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_DEBUG+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_DEBUG+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-custom-firebase-json]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-custom-firebase-json[`+++quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicate to use a custom firebase.json file instead of the automatically generated one. The custom firebase.json file MUST include a setting of
+
+```
+"host" : "0.0.0.0"
+```
+
+to ensure the ports of the emulator are exposed correctly at the docker container level.
+
+See the section on Custom Firebase Json in the docs for more info.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CUSTOM_FIREBASE_JSON+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CUSTOM_FIREBASE_JSON+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-enabled[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the service should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-emulator-port[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-logging-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-logging-port[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.logging-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.logging-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Port on which to expose the logging endpoint port. This is needed in case you want to view the logging via the Emulator UI.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_LOGGING_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_LOGGING_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-hub-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-hub-port[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.hub-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.hub-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Port on which to expose the hub endpoint port. This is needed if you want to use the hub API of the Emulator UI.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_HUB_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_HUB_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-expose-to-companion-containers]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-expose-to-companion-containers[`+++quarkus.google.cloud.devservices.firebase.emulator.expose-to-companion-containers+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.expose-to-companion-containers+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to expose the emulator's ports to companion containers this JVM starts via Testcontainers (e.g. a Playwright browser container), reachable via the `host.testcontainers.internal` ambassador hostname. Starts one small extra ambassador container (shared across the whole JVM, so this doesn't add up if other Dev Services already use it). Disable this if your tests never need a companion container to reach the emulator this way.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_EXPOSE_TO_COMPANION_CONTAINERS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_EXPOSE_TO_COMPANION_CONTAINERS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-enabled[`+++quarkus.google.cloud.devservices.firebase.auth.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.auth.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-emulator-port[`+++quarkus.google.cloud.devservices.firebase.auth.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.auth.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-enabled[`+++quarkus.google.cloud.devservices.firebase.hosting.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-emulator-port[`+++quarkus.google.cloud.devservices.firebase.hosting.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-hosting-path]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-hosting-path[`+++quarkus.google.cloud.devservices.firebase.hosting.hosting-path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.hosting-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the hosting files. Takes precedence over a custom firebase.json's own `hosting.public`/`hosting.source`, if `quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json` is also set -- see the docs section on Custom Firebase JSON for why you may need this.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_HOSTING_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_HOSTING_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-vite-hmr-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-vite-hmr-port[`+++quarkus.google.cloud.devservices.firebase.hosting.vite.hmr-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.vite.hmr-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The port the project's own Vite dev server is configured to listen on (the `server.port` setting in `vite.config.js`/`vite.config.ts`), and therefore also the port the browser's Vite HMR (hot module reload) client tries to reconnect on. Only relevant when the hosting directory is detected as a Vite project. Defaults to Vite's own default of 5173, which is what Firebase's emulator uses when it spawns the dev server without any `server.port` override present.
+
+If your `vite.config` customizes `server.port`, set this to the same value so the emulator publishes the port the HMR client actually needs to reach. It's recommended to also set `server.strictPort: true` in `vite.config`, so Vite fails fast instead of silently picking a different port if this one turns out to be unavailable.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_VITE_HMR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_VITE_HMR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-enabled[`+++quarkus.google.cloud.devservices.firebase.database.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.database.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-emulator-port[`+++quarkus.google.cloud.devservices.firebase.database.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.database.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-enabled[`+++quarkus.google.cloud.devservices.firebase.firestore.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-emulator-port[`+++quarkus.google.cloud.devservices.firebase.firestore.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-websocket-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-websocket-port[`+++quarkus.google.cloud.devservices.firebase.firestore.websocket-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.websocket-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Port on which to expose the websocket port. This is needed in case the Firestore Emulator UI needs is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_WEBSOCKET_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_WEBSOCKET_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-rules-file]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-rules-file[`+++quarkus.google.cloud.devservices.firebase.firestore.rules-file+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.rules-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the firestore.rules file.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_RULES_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_RULES_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-indexes-file]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-indexes-file[`+++quarkus.google.cloud.devservices.firebase.firestore.indexes-file+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.indexes-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the firestore.indexes.json file.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_INDEXES_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_INDEXES_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-enabled[`+++quarkus.google.cloud.devservices.functions.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.functions.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-emulator-port[`+++quarkus.google.cloud.devservices.functions.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.functions.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-functions-path]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-functions-path[`+++quarkus.google.cloud.devservices.functions.functions-path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.functions.functions-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the functions source directory. Takes precedence over a custom firebase.json's own `functions.source`, if `quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json` is also set -- see the docs section on Custom Firebase JSON for why you may need this.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_FUNCTIONS_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_FUNCTIONS_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled[`+++quarkus.google.cloud.devservices.pubsub.enabled+++`]##

--- a/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices_quarkus.google.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-google-cloud-firebase-devservices_quarkus.google.adoc
@@ -592,7 +592,7 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-Path to the hosting files.
+Path to the hosting files. Takes precedence over a custom firebase.json's own `hosting.public`/`hosting.source`, if `quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json` is also set -- see the docs section on Custom Firebase JSON for why you may need this.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -815,6 +815,963 @@ Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_EMULATOR_PO
 endif::add-copy-button-to-env-var[]
 --
 |int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled[`+++quarkus.google.cloud.devservices.pubsub.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.pubsub.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-emulator-port[`+++quarkus.google.cloud.devservices.pubsub.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.pubsub.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PUBSUB_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-enabled[`+++quarkus.google.cloud.devservices.storage.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.storage.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-emulator-port[`+++quarkus.google.cloud.devservices.storage.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.storage.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-rules-file]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-storage-rules-file[`+++quarkus.google.cloud.devservices.storage.rules-file+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.storage.rules-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the storage.rules file.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_RULES_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_STORAGE_RULES_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-project-id]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-project-id[`+++quarkus.google.cloud.devservices.project-id+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.project-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Google Cloud project ID. The project is required to be set if you use the Firebase Auth Dev service.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PROJECT_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_PROJECT_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-prefer-firebase-dev-services]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-prefer-firebase-dev-services[`+++quarkus.google.cloud.devservices.firebase.prefer-firebase-dev-services+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.prefer-firebase-dev-services+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates to use the dev service for Firebase. The default value is true. This indicator is used to detect the Firebase DevService and disable the DevServices for extensions which conflict with the Firebase DevService.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_PREFER_FIREBASE_DEV_SERVICES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_PREFER_FIREBASE_DEV_SERVICES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-firebase-version]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-firebase-version[`+++quarkus.google.cloud.devservices.firebase.emulator.firebase-version+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.firebase-version+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The version of the firebase tools to use. Default is to auto-detect it from a package.json file or else use the latest available version.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_FIREBASE_VERSION+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_FIREBASE_VERSION+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-image-name]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-image-name[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.image-name+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.image-name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the Docker image name for the Google Cloud SDK. This image is used to emulate the Pub/Sub service in the development environment. The default value is 'node:23-alpine'.
+
+See also the documentation on Custom Docker images for more info about this image.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_IMAGE_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_IMAGE_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|`+++node:20-alpine+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Id of the docker user to run the firebase executable. This is needed in environments where Docker does not perform a mapping to the user running Docker. In a Docker Desktop setup, Docker automatically performs this mapping and the data written by the emulator can be read by the user running the build. This is not the case in a regular (non-Desktop) setup, so you may need to set the user id and `docker-group()`. This option is often needed in CI environments.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Id of the group to which the `docker-user()` belongs.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user-env]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-user-env[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user-env+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-user-env+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Try to read the `docker-user()` from an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER_ENV+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_USER_ENV+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group-env]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-docker-group-env[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group-env+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.docker-group-env+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Try to read the `docker-group()` from an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP_ENV+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_DOCKER_GROUP_ENV+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-auto-detect-user-and-group]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-auto-detect-user-and-group[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.auto-detect-user-and-group+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.auto-detect-user-and-group+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Automatically try to detect the `docker-user()` and `docker-group()` based on the current user. This is the default. Note that this setting is overridden by any of the previous ways to set the uid/gid.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_AUTO_DETECT_USER_AND_GROUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_AUTO_DETECT_USER_AND_GROUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-out]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-out[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-out+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-out+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Pipe Stdout of the container to the Quarkus logging
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_OUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_OUT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-err]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-follow-std-err[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-err+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.follow-std-err+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Pipe Stedd of the container to the Quarkus logging
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_ERR+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_FOLLOW_STD_ERR+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-docker-env-vars-env-vars[`+++quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.docker.env-vars."env-vars"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+List of additional environment variables and values which can be passed into the docker image. These variables can be picked up by some webframeworks or functions (see the firebase documentation). This feature can e.g. be used to pass in for example the port the Quarkus application is exposing.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_DOCKER_ENV_VARS__ENV_VARS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-token[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.token+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.token+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The token to use for firebase authentication. Run `firebase login:ci` locally to get a new token. This option is mandatory if you use firebase hosting.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_TOKEN+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_TOKEN+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-java-tool-options]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-java-tool-options[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.java-tool-options+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.java-tool-options+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Sets the JAVA tool options for emulators based on the Java runtime environment like -Xmx. See also link:https://firebase.google.com/docs/emulator-suite/install_and_configure#specifying_java_options[here]
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_JAVA_TOOL_OPTIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_JAVA_TOOL_OPTIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-emulator-data]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-emulator-data[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.emulator-data+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.emulator-data+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Allow to import and export data. Specify a path relative to the current working directory of the executable (for most unit tests, this is the root of the build directory) to be used for import and export of emulator data. The data will be written to a subdirectory called "emulator-data" of this directory. See also link:https://firebase.google.com/docs/emulator-suite/install_and_configure#export_and_import_emulator_data[here]
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EMULATOR_DATA+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EMULATOR_DATA+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-import-export]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-import-export[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.import-export+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.import-export+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicate whether to import, export or both the data specified in `emulator-data()`
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_IMPORT_EXPORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_IMPORT_EXPORT+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`import-only`, `export-only`, `import-export`
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-experiments]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-experiments[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.experiments+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.experiments+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates the set of experimental features from firebase to enable (using the firebase experiment:enable command line option).
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EXPERIMENTS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_EXPERIMENTS+++`
+endif::add-copy-button-to-env-var[]
+--
+|list of string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-debug]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-cli-debug[`+++quarkus.google.cloud.devservices.firebase.emulator.cli.debug+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.cli.debug+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Enable firebase emulators debugging.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_DEBUG+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CLI_DEBUG+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-custom-firebase-json]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-custom-firebase-json[`+++quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicate to use a custom firebase.json file instead of the automatically generated one. The custom firebase.json file MUST include a setting of
+
+```
+"host" : "0.0.0.0"
+```
+
+to ensure the ports of the emulator are exposed correctly at the docker container level.
+
+See the section on Custom Firebase Json in the docs for more info.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CUSTOM_FIREBASE_JSON+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_CUSTOM_FIREBASE_JSON+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-enabled[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the service should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-emulator-port[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-logging-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-logging-port[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.logging-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.logging-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Port on which to expose the logging endpoint port. This is needed in case you want to view the logging via the Emulator UI.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_LOGGING_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_LOGGING_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-hub-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-ui-hub-port[`+++quarkus.google.cloud.devservices.firebase.emulator.ui.hub-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.ui.hub-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Port on which to expose the hub endpoint port. This is needed if you want to use the hub API of the Emulator UI.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_HUB_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_UI_HUB_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-expose-to-companion-containers]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-emulator-expose-to-companion-containers[`+++quarkus.google.cloud.devservices.firebase.emulator.expose-to-companion-containers+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.emulator.expose-to-companion-containers+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to expose the emulator's ports to companion containers this JVM starts via Testcontainers (e.g. a Playwright browser container), reachable via the `host.testcontainers.internal` ambassador hostname. Starts one small extra ambassador container (shared across the whole JVM, so this doesn't add up if other Dev Services already use it). Disable this if your tests never need a companion container to reach the emulator this way.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_EXPOSE_TO_COMPANION_CONTAINERS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_EMULATOR_EXPOSE_TO_COMPANION_CONTAINERS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-enabled[`+++quarkus.google.cloud.devservices.firebase.auth.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.auth.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-auth-emulator-port[`+++quarkus.google.cloud.devservices.firebase.auth.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.auth.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_AUTH_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-enabled[`+++quarkus.google.cloud.devservices.firebase.hosting.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-emulator-port[`+++quarkus.google.cloud.devservices.firebase.hosting.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-hosting-path]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-hosting-path[`+++quarkus.google.cloud.devservices.firebase.hosting.hosting-path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.hosting-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the hosting files. Takes precedence over a custom firebase.json's own `hosting.public`/`hosting.source`, if `quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json` is also set -- see the docs section on Custom Firebase JSON for why you may need this.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_HOSTING_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_HOSTING_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-vite-hmr-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-hosting-vite-hmr-port[`+++quarkus.google.cloud.devservices.firebase.hosting.vite.hmr-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.hosting.vite.hmr-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The port the project's own Vite dev server is configured to listen on (the `server.port` setting in `vite.config.js`/`vite.config.ts`), and therefore also the port the browser's Vite HMR (hot module reload) client tries to reconnect on. Only relevant when the hosting directory is detected as a Vite project. Defaults to Vite's own default of 5173, which is what Firebase's emulator uses when it spawns the dev server without any `server.port` override present.
+
+If your `vite.config` customizes `server.port`, set this to the same value so the emulator publishes the port the HMR client actually needs to reach. It's recommended to also set `server.strictPort: true` in `vite.config`, so Vite fails fast instead of silently picking a different port if this one turns out to be unavailable.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_VITE_HMR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_HOSTING_VITE_HMR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-enabled[`+++quarkus.google.cloud.devservices.firebase.database.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.database.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-database-emulator-port[`+++quarkus.google.cloud.devservices.firebase.database.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.database.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_DATABASE_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-enabled[`+++quarkus.google.cloud.devservices.firebase.firestore.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-emulator-port[`+++quarkus.google.cloud.devservices.firebase.firestore.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-websocket-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-websocket-port[`+++quarkus.google.cloud.devservices.firebase.firestore.websocket-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.websocket-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Port on which to expose the websocket port. This is needed in case the Firestore Emulator UI needs is used.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_WEBSOCKET_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_WEBSOCKET_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-rules-file]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-rules-file[`+++quarkus.google.cloud.devservices.firebase.firestore.rules-file+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.rules-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the firestore.rules file.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_RULES_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_RULES_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-indexes-file]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-firebase-firestore-indexes-file[`+++quarkus.google.cloud.devservices.firebase.firestore.indexes-file+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.firebase.firestore.indexes-file+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the firestore.indexes.json file.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_INDEXES_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FIREBASE_FIRESTORE_INDEXES_FILE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-enabled[`+++quarkus.google.cloud.devservices.functions.enabled+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.functions.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Indicates whether the DevService should be enabled or not. The default value is 'false'.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-emulator-port]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-emulator-port[`+++quarkus.google.cloud.devservices.functions.emulator-port+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.functions.emulator-port+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Specifies the emulatorPort on which the service should run in the development environment. The default is to expose the service on a random port.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_EMULATOR_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_EMULATOR_PORT+++`
+endif::add-copy-button-to-env-var[]
+--
+|int
+|
+
+a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-functions-path]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-functions-functions-path[`+++quarkus.google.cloud.devservices.functions.functions-path+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.google.cloud.devservices.functions.functions-path+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Path to the functions source directory. Takes precedence over a custom firebase.json's own `functions.source`, if `quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json` is also set -- see the docs section on Custom Firebase JSON for why you may need this.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_FUNCTIONS_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_GOOGLE_CLOUD_DEVSERVICES_FUNCTIONS_FUNCTIONS_PATH+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
 |
 
 a|icon:lock[title=Fixed at build time] [[quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled]] [.property-path]##link:#quarkus-google-cloud-firebase-devservices_quarkus-google-cloud-devservices-pubsub-enabled[`+++quarkus.google.cloud.devservices.pubsub.enabled+++`]##

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceConfig.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseDevServiceConfig.java
@@ -35,7 +35,7 @@ public interface FirebaseDevServiceConfig {
     /**
      * Configuration for the Functions emulator
      */
-    GenericDevService functions();
+    FunctionsDevService functions();
 
     /**
      * Configuration for the Google Cloud PubSub emulator
@@ -267,7 +267,10 @@ public interface FirebaseDevServiceConfig {
         interface HostingDevService extends GenericDevService {
 
             /**
-             * Path to the hosting files.
+             * Path to the hosting files. Takes precedence over a custom firebase.json's own
+             * {@code hosting.public}/{@code hosting.source}, if
+             * {@code quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json} is also set --
+             * see the docs section on Custom Firebase JSON for why you may need this.
              */
             Optional<String> hostingPath();
 
@@ -325,6 +328,16 @@ public interface FirebaseDevServiceConfig {
          * Path to the storage.rules file.
          */
         Optional<String> rulesFile();
+    }
+
+    interface FunctionsDevService extends GenericDevService {
+
+        /**
+         * Path to the functions source directory. Takes precedence over a custom firebase.json's own
+         * {@code functions.source}, if {@code quarkus.google.cloud.devservices.firebase.emulator.custom-firebase-json}
+         * is also set -- see the docs section on Custom Firebase JSON for why you may need this.
+         */
+        Optional<String> functionsPath();
     }
 
     /**

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilder.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilder.java
@@ -109,6 +109,17 @@ public class FirebaseEmulatorConfigBuilder {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+
+        // The custom firebase.json itself can't express a build-environment-dependent path (it's plain JSON,
+        // also consumed by the real `firebase` CLI, with no property placeholder support) -- these devservices
+        // config values, when set, override whatever it says. See Builder#overrideHostingPath's javadoc.
+        config.firebase().hosting().hostingPath()
+                .map(FirebaseEmulatorConfigBuilder::asPath)
+                .ifPresent(builder::overrideHostingPath);
+
+        config.functions().functionsPath()
+                .map(FirebaseEmulatorConfigBuilder::asPath)
+                .ifPresent(builder::overrideFunctionsPath);
     }
 
     private void configureEmulators(FirebaseEmulatorContainer.Builder builder) {
@@ -184,6 +195,11 @@ public class FirebaseEmulatorConfigBuilder {
                 .rulesFile()
                 .map(FirebaseEmulatorConfigBuilder::asPath)
                 .ifPresent(firebaseConfigBuilder::withStorageRules);
+
+        config.functions()
+                .functionsPath()
+                .map(FirebaseEmulatorConfigBuilder::asPath)
+                .ifPresent(firebaseConfigBuilder::withFunctionsFromPath);
 
         firebaseConfigBuilder.done();
     }

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/CustomFirebaseConfigReader.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/CustomFirebaseConfigReader.java
@@ -168,6 +168,7 @@ class CustomFirebaseConfigReader {
 
             return new FirebaseEmulatorContainer.HostingConfig(
                     publicDir,
+                    Optional.empty(),
                     Optional.empty());
         } else {
             return FirebaseEmulatorContainer.HostingConfig.DEFAULT;

--- a/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
+++ b/firebase-devservices/deployment/src/main/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainer.java
@@ -254,15 +254,28 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
     /**
      * Firebase hosting configuration
      *
-     * @param hostingContentDir The path to the directory containing the hosting content
+     * @param hostingContentDir The path to the directory containing the hosting content, as declared by a custom
+     *        firebase.json's own {@code hosting.public}/{@code hosting.source} field (or set directly via
+     *        {@link FirebaseConfigBuilder#withHostingPath(Path)} when not reading from a firebase.json at all).
+     *        firebase-tools requires this to stay relative to firebase.json's own location, so this value is never
+     *        touched by {@link Builder#overrideHostingPath(Path)} -- see {@link #hostingOverride}.
+     * @param hostingOverride A caller-supplied host-side bind-mount source that takes precedence over
+     *        {@link #hostingContentDir} for locating the actual hosting content on disk, without affecting the
+     *        container-side path firebase-tools itself uses (which is always derived from
+     *        {@link #hostingContentDir}). Unlike {@link #hostingContentDir}, this may be absolute -- host-side path
+     *        resolution is environment-specific (e.g. a CI container's own bind-mount namespace) and has no
+     *        bearing on firebase.json's relative-path requirement. Set via
+     *        {@link Builder#overrideHostingPath(Path)}.
      * @param viteHmrPort The port the project's own vite.config.js configures the Vite dev server (and therefore
      *        its HMR client) to use, or empty to use Vite's default (see {@link ViteWebFramework#DEFAULT_HMR_PORT})
      */
     public record HostingConfig(
             Optional<Path> hostingContentDir,
+            Optional<Path> hostingOverride,
             Optional<Integer> viteHmrPort) {
 
         public static final HostingConfig DEFAULT = new HostingConfig(
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
     }
@@ -410,6 +423,55 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             this.firebaseConfig = reader.readFromFirebase(customFirebaseJson);
             this.customFirebaseJson = customFirebaseJson;
             return this;
+        }
+
+        /**
+         * Override the host-side hosting content directory of the {@link FirebaseConfig} already configured on
+         * this builder (typically via {@link #readFromFirebaseJson(Path)}), without disturbing the firebase.json-
+         * declared value the container side relies on. See {@link HostingConfig#hostingOverride}.
+         *
+         * @param hostingContentDir The hosting directory to bind-mount from instead
+         * @return This builder
+         * @throws IllegalStateException if no {@link FirebaseConfig} has been configured yet
+         */
+        public Builder overrideHostingPath(Path hostingContentDir) {
+            requireFirebaseConfig();
+            this.firebaseConfig = new FirebaseConfig(
+                    new HostingConfig(
+                            this.firebaseConfig.hostingConfig().hostingContentDir(),
+                            Optional.of(hostingContentDir),
+                            this.firebaseConfig.hostingConfig().viteHmrPort()),
+                    this.firebaseConfig.storageConfig(),
+                    this.firebaseConfig.firestoreConfig(),
+                    this.firebaseConfig.functionsConfig(),
+                    this.firebaseConfig.services());
+            return this;
+        }
+
+        /**
+         * The {@link FunctionsConfig} equivalent of {@link #overrideHostingPath(Path)}
+         *
+         * @param functionsPath The functions source directory to use instead
+         * @return This builder
+         * @throws IllegalStateException if no {@link FirebaseConfig} has been configured yet
+         */
+        public Builder overrideFunctionsPath(Path functionsPath) {
+            requireFirebaseConfig();
+            this.firebaseConfig = new FirebaseConfig(
+                    this.firebaseConfig.hostingConfig(),
+                    this.firebaseConfig.storageConfig(),
+                    this.firebaseConfig.firestoreConfig(),
+                    new FunctionsConfig(Optional.of(functionsPath), this.firebaseConfig.functionsConfig().ignores()),
+                    this.firebaseConfig.services());
+            return this;
+        }
+
+        private void requireFirebaseConfig() {
+            if (this.firebaseConfig == null) {
+                throw new IllegalStateException(
+                        "No Firebase configuration has been set yet -- call readFromFirebaseJson(...) or "
+                                + "withFirebaseConfig()...done() before overriding a specific path");
+            }
         }
 
         /**
@@ -858,6 +920,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             public FirebaseConfigBuilder withHostingPath(Path hostingContentDir) {
                 this.hostingConfig = new HostingConfig(
                         Optional.of(hostingContentDir),
+                        this.hostingConfig.hostingOverride(),
                         this.hostingConfig.viteHmrPort());
                 return this;
             }
@@ -873,6 +936,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
             public FirebaseConfigBuilder withViteHmrPort(int viteHmrPort) {
                 this.hostingConfig = new HostingConfig(
                         this.hostingConfig.hostingContentDir(),
+                        this.hostingConfig.hostingOverride(),
                         Optional.of(viteHmrPort));
                 return this;
             }
@@ -1094,7 +1158,7 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
         emulatorConfig.cliArguments().emulatorData().ifPresent(path -> {
             // https://firebase.google.com/docs/emulator-suite/install_and_configure#export_and_import_emulator_data
             // Mount the volume to the specified path
-            this.withFileSystemBind(path.toString(), EMULATOR_DATA_PATH, BindMode.READ_WRITE);
+            this.withFileSystemBind(path.toAbsolutePath().toString(), EMULATOR_DATA_PATH, BindMode.READ_WRITE);
         });
 
         if (this.services.containsKey(Emulator.FIREBASE_HOSTING)) {
@@ -1125,13 +1189,13 @@ public class FirebaseEmulatorContainer extends GenericContainer<FirebaseEmulator
      * The local (host machine) directory holding the hosting content, which gets bind-mounted into the
      * container. This is where {@link WebFramework} detection looks for framework-specific files, since the
      * container's own filesystem doesn't have the hosting content available until the volume is mounted at
-     * container startup.
+     * container startup. Prefers {@link HostingConfig#hostingOverride} over {@link HostingConfig#hostingContentDir}
+     * -- see {@link HostingConfig}'s own doc for why the two are kept separate.
      */
     private static Path hostHostingPath(EmulatorConfig emulatorConfig) {
-        return emulatorConfig
-                .firebaseConfig()
-                .hostingConfig()
-                .hostingContentDir()
+        var hostingConfig = emulatorConfig.firebaseConfig().hostingConfig();
+        return hostingConfig.hostingOverride()
+                .or(hostingConfig::hostingContentDir)
                 .orElseGet(() -> new File(FirebaseJsonBuilder.FIREBASE_HOSTING_SUBPATH).getAbsoluteFile().toPath());
     }
 

--- a/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilderTest.java
+++ b/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/FirebaseEmulatorConfigBuilderTest.java
@@ -64,9 +64,10 @@ class FirebaseEmulatorConfigBuilderTest {
                                 Optional.of(6007),
                                 Optional.of("firestore.rules"),
                                 Optional.of("firestore.indexes.json"))),
-                new TestGenericDevService(
+                new TestFunctionsDevService(
                         true,
-                        Optional.of(6008)),
+                        Optional.of(6008),
+                        Optional.empty()),
                 new TestGenericDevService(
                         true,
                         Optional.of(6009)),
@@ -138,6 +139,83 @@ class FirebaseEmulatorConfigBuilderTest {
         assertNull(exposedPorts.get(FirebaseEmulatorContainer.Emulator.REALTIME_DATABASE));
     }
 
+    // src/test/firebase.json (used by the Testcontainers-backed
+    // testcontainers.FirebaseEmulatorContainerCustomConfigTest too) sets hosting.public="hosting" and
+    // functions.source="functions" -- these tests only build the config (no container start), so they stay
+    // fast/Docker-free while still exercising the real file the plain-JSON parsing reads.
+    private static final String CUSTOM_FIREBASE_JSON = "src/test/firebase.json";
+
+    @Test
+    void testCustomFirebaseJsonAppliesHostingAndFunctionsPathOverride() {
+        var configBuilder = customFirebaseJsonConfigBuilder(
+                Optional.of("overridden-hosting"),
+                Optional.of("overridden-functions"));
+
+        var firebaseConfig = configBuilder.buildConfig().firebaseConfig();
+
+        assertPathEndsWith("overridden-hosting", firebaseConfig.hostingConfig().hostingOverride().orElse(null));
+        assertPathEndsWith("overridden-functions", firebaseConfig.functionsConfig().functionsPath().orElse(null));
+        assertPathEndsWith("hosting", firebaseConfig.hostingConfig().hostingContentDir().orElse(null));
+        // Everything else that came from the custom firebase.json must survive the override untouched.
+        assertPathEndsWith("firestore.rules", firebaseConfig.firestoreConfig().rulesFile().orElse(null));
+        assertPathEndsWith("storage.rules", firebaseConfig.storageConfig().rulesFile().orElse(null));
+    }
+
+    @Test
+    void testCustomFirebaseJsonWithoutOverrideKeepsOriginalPaths() {
+        var configBuilder = customFirebaseJsonConfigBuilder(Optional.empty(), Optional.empty());
+
+        var firebaseConfig = configBuilder.buildConfig().firebaseConfig();
+
+        assertPathEndsWith("hosting", firebaseConfig.hostingConfig().hostingContentDir().orElse(null));
+        assertPathEndsWith("functions", firebaseConfig.functionsConfig().functionsPath().orElse(null));
+    }
+
+    private FirebaseEmulatorConfigBuilder customFirebaseJsonConfigBuilder(
+            Optional<String> hostingPathOverride,
+            Optional<String> functionsPathOverride) {
+        var projectConfig = new TestProjectConfig(Optional.of("my-project-id"));
+        var config = new TestFirebaseDevServiceConfig(
+                new TestFirebase(
+                        true,
+                        new TestFirebaseEmulator(
+                                Optional.empty(),
+                                new TestDocker(
+                                        "node:21-alpine",
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        true,
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Map.of()),
+                                new TestCli(
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()),
+                                Optional.of(CUSTOM_FIREBASE_JSON),
+                                new TestUI(false, Optional.empty(), Optional.empty(), Optional.empty()),
+                                true),
+                        new TestGenericDevService(false, Optional.empty()),
+                        new TestHosting(
+                                false,
+                                Optional.empty(),
+                                hostingPathOverride,
+                                new TestVite(Optional.empty())),
+                        new TestGenericDevService(false, Optional.empty()),
+                        new TestFirestoreDevService(
+                                false, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())),
+                new TestFunctionsDevService(false, Optional.empty(), functionsPathOverride),
+                new TestGenericDevService(false, Optional.empty()),
+                new TestStorageDevService(false, Optional.empty(), Optional.empty()));
+
+        return new FirebaseEmulatorConfigBuilder(projectConfig, config, true);
+    }
+
     // Record implementations for interfaces
     record TestProjectConfig(
             Optional<String> projectId) implements FirebaseDevServiceProjectConfig {
@@ -145,7 +223,7 @@ class FirebaseEmulatorConfigBuilderTest {
 
     record TestFirebaseDevServiceConfig(
             FirebaseDevServiceConfig.Firebase firebase,
-            FirebaseDevServiceConfig.GenericDevService functions,
+            FirebaseDevServiceConfig.FunctionsDevService functions,
             FirebaseDevServiceConfig.GenericDevService pubsub,
             FirebaseDevServiceConfig.StorageDevService storage) implements FirebaseDevServiceConfig {
     }
@@ -228,6 +306,12 @@ class FirebaseEmulatorConfigBuilderTest {
     record TestGenericDevService(
             boolean enabled,
             Optional<Integer> emulatorPort) implements FirebaseDevServiceConfig.GenericDevService {
+    }
+
+    record TestFunctionsDevService(
+            boolean enabled,
+            Optional<Integer> emulatorPort,
+            Optional<String> functionsPath) implements FirebaseDevServiceConfig.FunctionsDevService {
     }
 
 }

--- a/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainerBuilderOverrideTest.java
+++ b/firebase-devservices/deployment/src/test/java/io/quarkiverse/googlecloudservices/firebase/deployment/testcontainers/FirebaseEmulatorContainerBuilderOverrideTest.java
@@ -1,0 +1,74 @@
+package io.quarkiverse.googlecloudservices.firebase.deployment.testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link FirebaseEmulatorContainer.Builder#overrideHostingPath(Path)} and
+ * {@link FirebaseEmulatorContainer.Builder#overrideFunctionsPath(Path)} -- the mechanism that lets devservices
+ * config win over a custom firebase.json's own hosting/functions path. See
+ * {@code FirebaseEmulatorConfigBuilderTest} for the config-layer wiring of that same mechanism, and
+ * {@link FirebaseEmulatorContainerCustomConfigTest} for the Docker-backed test that starts a real container from
+ * this same fixture file without any override applied.
+ */
+class FirebaseEmulatorContainerBuilderOverrideTest {
+
+    private static final File CUSTOM_FIREBASE_JSON = new File("src/test/firebase.json");
+
+    @Test
+    void overrideHostingPathReplacesOnlyTheHostingDirectory() throws IOException {
+        var builder = FirebaseEmulatorContainer.builder()
+                .readFromFirebaseJson(CUSTOM_FIREBASE_JSON.toPath());
+
+        var before = builder.buildConfig().firebaseConfig();
+        builder.overrideHostingPath(Path.of("some-other-hosting-dir"));
+        var after = builder.buildConfig().firebaseConfig();
+
+        assertEquals("some-other-hosting-dir", after.hostingConfig().hostingOverride().orElseThrow().toString());
+        // hostingContentDir -- firebase.json's own declared, always-relative hosting source, which the
+        // container side relies on -- must survive the override untouched.
+        assertEquals(before.hostingConfig().hostingContentDir(), after.hostingConfig().hostingContentDir());
+        // Everything else must survive the override untouched.
+        assertEquals(before.functionsConfig(), after.functionsConfig());
+        assertEquals(before.storageConfig(), after.storageConfig());
+        assertEquals(before.firestoreConfig(), after.firestoreConfig());
+        assertEquals(before.services(), after.services());
+    }
+
+    @Test
+    void overrideFunctionsPathReplacesOnlyTheFunctionsDirectory() throws IOException {
+        var builder = FirebaseEmulatorContainer.builder()
+                .readFromFirebaseJson(CUSTOM_FIREBASE_JSON.toPath());
+
+        var before = builder.buildConfig().firebaseConfig();
+        builder.overrideFunctionsPath(Path.of("some-other-functions-dir"));
+        var after = builder.buildConfig().firebaseConfig();
+
+        assertEquals("some-other-functions-dir", after.functionsConfig().functionsPath().orElseThrow().toString());
+        // Everything else must survive the override untouched.
+        assertEquals(before.hostingConfig(), after.hostingConfig());
+        assertEquals(before.storageConfig(), after.storageConfig());
+        assertEquals(before.firestoreConfig(), after.firestoreConfig());
+        assertEquals(before.services(), after.services());
+    }
+
+    @Test
+    void overrideHostingPathBeforeAnyConfigIsLoadedThrows() {
+        var builder = FirebaseEmulatorContainer.builder();
+
+        assertThrows(IllegalStateException.class, () -> builder.overrideHostingPath(Path.of("hosting")));
+    }
+
+    @Test
+    void overrideFunctionsPathBeforeAnyConfigIsLoadedThrows() {
+        var builder = FirebaseEmulatorContainer.builder();
+
+        assertThrows(IllegalStateException.class, () -> builder.overrideFunctionsPath(Path.of("functions")));
+    }
+}


### PR DESCRIPTION
Firebase.json can guess the wrong directory when running DinD or DoD e.g. on CI enviroments. This allows to setup the correct directories from config, while still using the firebase.json file.

Also mounted the emulator data based on an absolute path.